### PR TITLE
Fix #10126 Use NGramField to allow searching partial terms.

### DIFF
--- a/qgis-app/plugins/search_indexes.py
+++ b/qgis-app/plugins/search_indexes.py
@@ -4,7 +4,7 @@ from plugins.models import Plugin
 
 
 class PluginIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.CharField(document=True, use_template=True)
+    text = indexes.NgramField(document=True, use_template=True)
     created_by = indexes.CharField(model_attr='created_by')
     created_on = indexes.DateTimeField(model_attr='created_on')
     # We add this for autocomplete.


### PR DESCRIPTION
Hi @elpaso, @pcav, @timlinux, this will fix http://hub.qgis.org/issues/10126 to allow searching partial terms. We need to update or rebuild the index again though.