### PR TITLE
"Fresh" Plugin and Add "Created on" Column

### DIFF
--- a/qgis-app/plugins/models.py
+++ b/qgis-app/plugins/models.py
@@ -16,7 +16,7 @@ from djangoratings.fields import AnonymousRatingField
 from taggit_autosuggest.managers import TaggableManager
 
 PLUGINS_STORAGE_PATH = getattr(settings, 'PLUGINS_STORAGE_PATH', 'packages/%Y')
-PLUGINS_FRESH_DAYS   = getattr(settings, 'PLUGINS_FRESH_DAYS', 30)
+PLUGINS_FRESH_DAYS = getattr(settings, 'PLUGINS_FRESH_DAYS', 7)
 
 
 # Used in Version fields to transform DB value back to human readable string
@@ -69,7 +69,6 @@ class FeaturedPlugins(BasePluginManager):
     def get_queryset(self):
         return super(FeaturedPlugins, self).get_queryset().filter(pluginversion__approved=True, featured=True).order_by('-created_on').distinct()
 
-
 class FreshPlugins(BasePluginManager):
     """
     Shows only approved plugins: i.e. those with "approved" version flag set
@@ -81,7 +80,11 @@ class FreshPlugins(BasePluginManager):
         return super(FreshPlugins, self).__init__(*args, **kwargs)
 
     def get_queryset(self):
-        return super(FreshPlugins, self).get_queryset().filter(deprecated=False, pluginversion__approved=True, modified_on__gte = datetime.datetime.now()- datetime.timedelta(days = self.days)).order_by('-created_on').distinct()
+        return super(FreshPlugins, self).get_queryset().filter(
+            deprecated=False,
+            pluginversion__approved=True,
+            modified_on__gte=datetime.datetime.now() - datetime.timedelta(days=self.days)
+        ).order_by('-modified_on').distinct()
 
 
 class UnapprovedPlugins(BasePluginManager):
@@ -98,7 +101,6 @@ class DeprecatedPlugins(BasePluginManager):
     """
     def get_queryset(self):
         return super(DeprecatedPlugins, self).get_queryset().filter(deprecated=True).distinct()
-
 
 
 class PopularPlugins(ApprovedPlugins):

--- a/qgis-app/plugins/templates/plugins/plugin_base.html
+++ b/qgis-app/plugins/templates/plugins/plugin_base.html
@@ -23,6 +23,7 @@
         <li><a href="{% url "featured_plugins" %}">{% trans "Featured "%}</a></li>
         <li><a href="{% url "approved_plugins" %}">{% trans "All"%}</a></li>
         <li><a href="{% url "stable_plugins" %}">{% trans "Stable"%}</a></li>
+        <li><a href="{% url "fresh_plugins" %}">{% trans "Fresh" %}</a></li>
         <li><a href="{% url "experimental_plugins" %}">{% trans "Experimental"%}</a></li>
         <li><a href="{% url "popular_plugins" %}">{% trans "Popular" %}</a></li>
         <li><a href="{% url "most_voted_plugins" %}">{% trans "Most voted" %}</a></li>

--- a/qgis-app/plugins/templates/plugins/plugin_list.html
+++ b/qgis-app/plugins/templates/plugins/plugin_list.html
@@ -69,6 +69,7 @@
 <!--
                 <th>{% anchor modified_on "Last modified" %}</th>
 -->
+                <th>{% anchor created_on "Created on" %}</th>
                 <th>{% anchor average_vote "Stars (votes)" %}</th>
                 <th>{% trans "Stable" %}</th>
                 <th>{% trans "Exp." %}</th>
@@ -95,6 +96,7 @@
 <!--
                 <td>{{ object.modified_on|naturalday }}</td>
 -->
+                <td>{{ object.created_on|naturalday }}</td>
                 <td><div><div class="star-ratings"><span style="width:{% widthratio object.average_vote 5 100 %}%" class="rating"></span></div> ({{ object.rating_votes }})</div></td>
                 <td>{% if object.stable %}<a href="{% url "version_download" object.package_name object.stable.version %}" title="{% trans "Download the stable version" %}" >{{ object.stable.version }}</a>{% else %}&mdash;{% endif %}</td>
                 <td>{% if object.experimental %}<a href="{% url "version_download" object.package_name object.experimental.version %}" title="{% trans "Download the experimental version" %}" >{{ object.experimental.version }}</a>{% else %}&mdash;{% endif %}</td>


### PR DESCRIPTION
Hi @elpaso @pcav @timlinux, this PR is to address http://hub.qgis.org/issues/10302. 

- There was code already for 'Fresh' plugins, plugins that are updated within some period. I just set the period to be within 7 days. 
- I add "Created on" column, to know which one the newest plugins, or the oldest plugins (by sorting it)

Thanks