### PR TITLE
Replace the old user map

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -49,3 +49,5 @@ simplejson==3.3.3
 BeautifulSoup
 django-bootstrap-pagination
 django-sortable-listview
+# User map
+django-user-map

--- a/qgis-app/settings.py
+++ b/qgis-app/settings.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Django settings for qgis project.
 # ABP: More portable config
 import os
@@ -150,6 +151,12 @@ INSTALLED_APPS = (
     'userexport',
     'bootstrap_pagination',
     'sortable_listview',
+
+    'user_map',
+    'leaflet',
+    'bootstrapform',
+    'rest_framework',
+    'rest_framework_gis',
 )
 
 TEMPLATES = [
@@ -172,7 +179,6 @@ TEMPLATES = [
         },
     },
 ]
-
 
 ACCOUNT_ACTIVATION_DAYS = 7 # One-week activation window; you may, of course, use a different value
 
@@ -250,6 +256,65 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 THUMBNAIL_ENGINE='sorl.thumbnail.engines.convert_engine.Engine'
+
+USER_MAP = {
+    'project_name': 'QGIS',
+    'favicon_file': '/static/images/qgis-icon-32x32.png',
+    'login_view': 'fe_login',
+    'marker': {
+        'iconUrl': '/static/images/qgis-icon-32x32.png',
+        'iconSize': [32, 32],
+        'iconAnchor': [16, 0],
+    },
+    'leaflet_config': {
+        'TILES': [(
+            # The title
+            'MapQuest',
+            # Tile's URL
+            'http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png',
+            # More valid leaflet option is passed here
+            {
+                'attribution':
+                    '© <a href="http://www.openstreetmap.org" '
+                    'target="_parent">OpenStreetMap'
+                    '</a> and contributors, under an <a '
+                    'href="http://www.openstreetmap.org/copyright" '
+                    'target="_parent">open license</a>. Tiles Courtesy of '
+                    '<a '
+                    'href="http://www.mapquest.com/">MapQuest</a> <img '
+                    'src="http://developer.mapquest.com/content/osm/mq_logo'
+                    '.png"',
+                'maxZoom': 18,
+                'minZoom': 2,
+                'noWrap': True,
+                'subdomains': '1234'
+
+            }
+        )]
+    },
+    'roles': [
+        {
+            'id': 1,
+            'name': 'User',
+            'badge': 'user_map/img/badge-user.png'
+        },
+        {
+            'id': 2,
+            'name': 'Trainer',
+            'badge': 'user_map/img/badge-trainer.png'
+        },
+        {
+            'id': 3,
+            'name': 'Developer',
+            'badge': 'user_map/img/badge-developer.png'
+        }
+    ],
+    'api_user_fields': [
+        'username'
+    ],
+
+}
+
 
 # When run behind a proxy
 USE_X_FORWARDED_HOST = True

--- a/qgis-app/settings.py
+++ b/qgis-app/settings.py
@@ -264,7 +264,7 @@ USER_MAP = {
     'marker': {
         'iconUrl': '/static/images/qgis-icon-32x32.png',
         'iconSize': [32, 32],
-        'iconAnchor': [16, 0],
+        'popupAnchor': [0, -15]
     },
     'leaflet_config': {
         'TILES': [(

--- a/qgis-app/templates/user_map/extra_resource.html
+++ b/qgis-app/templates/user_map/extra_resource.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="/static/style/new/basic.css" type="text/css" />
+<link rel="stylesheet" href="/static/bootstrap/css/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" href="/static/style/new/qgis-style.css" type="text/css" />
+<link rel="stylesheet" href="/static/bootstrap/css/bootstrap-responsive.min.css" type="text/css" />
+<link rel="stylesheet" href="/static/font-awesome/css/font-awesome.min.css">
+
+
+<style>
+  body {
+    padding-top : 0px !important;
+  }
+  .navbar-fixed-top {
+    position: relative;
+  }
+</style>

--- a/qgis-app/templates/user_map/navigation.html
+++ b/qgis-app/templates/user_map/navigation.html
@@ -1,0 +1,41 @@
+{% load i18n simplemenu_tags %}
+<div id="navbar" class="navbar navbar-inverse navbar-fixed-top">
+    <div class="navbar-inner">
+        <div class="container">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+
+            <a class="brand" href="http://www.qgis.org">QGIS</a>
+            {% if user.is_authenticated %}
+            <a id="user-tooltip" href="{% url "fe_logout" %}" data-toggle="tooltip" data-placement="bottom" title="{{ user.username }}" style="float: right !important"><i class="icon-user icon-3x"></i></a>
+            {% else %}
+            <a href="{% url "fe_login" %}"><i class="icon-signin icon-3x"></i></a>
+            {% endif %}
+
+            <form class="navbar-search" action="/search/" method="get">
+              <input type="text"  id="id_q" name="q" class="search-query" placeholder="Search" />
+            </form>
+
+            {% get_simplemenu as menu %}
+             <div class="nav-collapse collapse">
+                <ul class="unstyled nav main-menu">
+                {% for item in menu %}
+                    <li><a href="{{ item.page.url }}">{{ item.name }}</a></li>
+                {% endfor %}
+                    {% if user.is_authenticated %}
+                    <li><a href="{% url "fe_logout" %}">{% trans "Logout" %}</a></li>
+                    {% else %}
+                    <li><a href="{% url "fe_login" %}">{% trans "Login" %}</a></li>
+                    {% endif %}
+                    {% block navigation_extra %}
+                    {% endblock %}
+                </ul>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/qgis-app/urls.py
+++ b/qgis-app/urls.py
@@ -34,8 +34,8 @@ urlpatterns =[
     url(r'^search/', include('haystack.urls')),
     url(r'^search/', include('custom_haystack_urls')),
 
-    # SAM: qgis-users app
-    url(r'^community-map/', include('users.urls')),
+    # AG: User Map
+    url(r'^community-map/', include('user_map.urls', namespace='user_map')),
     # Fix broken URLS in feedjack
     url(r'^planet/feed/$', RedirectView.as_view(url='/planet/feed/atom/')),
     # Tim: Feedjack feed aggregator / planet


### PR DESCRIPTION
Hi @elpaso @timlinux @pcav,

This PR will replace the old usermap. The new one looks like this:
![qgis_user_map](https://cloud.githubusercontent.com/assets/992519/13687812/02840172-e71e-11e5-9105-927c78382062.png)

This it the documentation of django-user-map http://www.akbargumbira.com/django-user-map/

To get this installed, these steps are required:
* Install django-user-map (I added this package in REQUIREMENTS.txt)
* INSTALLED_APPS and url (/community-map) are also already updated
* USER_MAP configuration in settings.py is also included in this PR (Please configure it if you want to change something)
* Run ```python manage.py migrate user_map```
* Update collectstatic
