### PR TITLE
Fix typo in plugin_permission_deny.html

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_permission_deny.html
+++ b/qgis-app/plugins/templates/plugins/plugin_permission_deny.html
@@ -1,4 +1,4 @@
 {% extends 'plugins/plugin_base.html' %}{% load i18n %}
 {% block content %}
-    <div class="error">{% trans "You cannot modifiy this plugin." %}</div>
+    <div class="error">{% trans "You cannot modify this plugin." %}</div>
 {% endblock %}


### PR DESCRIPTION
Substitutes
You cannot ~~modifiy~~ this plugin.
with
You cannot **modify** this plugin.