### PR TITLE
issue82, enable display 'modified_on' column in frontend /plugins

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_list.html
+++ b/qgis-app/plugins/templates/plugins/plugin_list.html
@@ -66,9 +66,7 @@
                 <th>{% anchor featured %}</th>
                 <th>{% anchor downloads %}</th>
                 <th>{% anchor author "Author" %}</th>
-<!--
                 <th>{% anchor modified_on "Last modified" %}</th>
--->
                 <th>{% anchor created_on "Created on" %}</th>
                 <th>{% anchor average_vote "Stars (votes)" %}</th>
                 <th>{% trans "Stable" %}</th>
@@ -93,9 +91,7 @@
                 <td>{% if object.featured%}<img src="{% static "images/tick_16.png" %}" />{% else %}&mdash;{% endif %}</td>
                 <td>{{ object.downloads }}</td>
                 <td><a title="{% trans "See all plugins by"%} {{ object.author }}" href="{% url "author_plugins" object.author %}">{{ object.author }}</a></td>
-<!--
                 <td>{{ object.modified_on|naturalday }}</td>
--->
                 <td>{{ object.created_on|naturalday }}</td>
                 <td><div><div class="star-ratings"><span style="width:{% widthratio object.average_vote 5 100 %}%" class="rating"></span></div> ({{ object.rating_votes }})</div></td>
                 <td>{% if object.stable %}<a href="{% url "version_download" object.package_name object.stable.version %}" title="{% trans "Download the stable version" %}" >{{ object.stable.version }}</a>{% else %}&mdash;{% endif %}</td>


### PR DESCRIPTION
This PR is referring to issue #82.
user was comparing between fresh-page (**/plugins/fresh**) and plugins-page  (**/plugins/?sort=-created_on**).
Per issue description, user click on `created on` sort link in plugin table, and get the latest created plugins. however,  in fresh-page user cannot find the same plugins lists.

if I am not mistaken:

**query for** `/plugins/fresh`:
- deprecated false
- approved true
- modified_on > now() - PLUGINS_FRESH_DAYS

**query for**  `plugins/?sort=-created_on`:

- approved true
- order by created_on

I found that there were already last modified (modified_on) column in frontend: plugins table which has been disabled with `<!-- -->` comment. 


This PR does enable display `last modified` column in plugins table.

In plugins landing page, user can sort last modified in order to get the fresh plugins list:

![imageedit_3_9434140401](https://user-images.githubusercontent.com/40058076/94637587-8c19f600-030a-11eb-9ade-242c34be19d9.gif)


The fresh plugins at /plugins/fresh/ displays list the plugins in reverse chronological order based on last modified:

<img width="302" alt="Screenshot 2020-09-30 at 10 52 35 AM" src="https://user-images.githubusercontent.com/40058076/94637843-1febc200-030b-11eb-882f-9a5316633aeb.png">
<img width="189" alt="Screenshot 2020-09-30 at 10 51 04 AM" src="https://user-images.githubusercontent.com/40058076/94637856-2a0dc080-030b-11eb-8ab3-425f77993a28.png">

