### PR TITLE
fixing---travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
     flake8
     --ignore=E203,E121,E122,E123,E124,E125,E126,E127,E128,E402
     --max-line-length 79
-    --exclude='./migrations/',
+    --exclude='./*/migrations/',
     ./styles
   - python manage.py makemigrations
   - python manage.py migrate


### PR DESCRIPTION
@timlinux @dimasciput 
This PR does modify travis.ci to fix the CI test. To exclude ./*/migrations/ in flake8 test