### PR TITLE
add email notification function in styles moderation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ Now set these options:
 * **Name:** Django Server
 * **Host:** 0.0.0.0
 * **Port:** 8080
-* **Additional options:** ``--settings=settings._docker``
+* **Additional options:** ``--settings=settings.docker``
 * **Run browser** If checked, it will open the url after you click run. You should be able to access the running on 0.0.0.0:62202 (the port that mapped to 8080)
 
 * **Environment vars** , you can add the variables value one-by-one by clicking on browse icon at right corner in the input field, or just copy-paste this value:
@@ -84,3 +84,28 @@ Now set these options:
 Now you can run the server using the green triangle next to the Django server
 label in the run configurations pull down. Debug will also work and you will be
 able to step through views etc as you work.
+
+---
+## Setup Style Managers Group
+
+The members of this group will receive style related emails.
+Follow these steps for setting up:
+- Open admin page: `http://0.0.0.0:62202/admin`, login with superuser account.
+- Create new Group: `Authentication and Authorization > Groups > Add group`
+- Set the options:
+  - **Name:** `Style Managers`
+  - **Permissions:** 
+    choose all styles | in **Available permissions** by typing `styles` in search input and click `Choose all`
+    - styles | style | Can add style
+    - styles | style | Can change style
+    - styles | style | Can delete style
+    - styles | style | Can view style
+    - styles | style review | Can add style review
+    - styles | style review | Can change style review
+    - styles | style review | Can delete style review
+    - styles | style review | Can view style review
+    - styles | style type | Can add style type
+    - styles | style type | Can change style type
+    - styles | style type | Can delete style type
+    - styles | style type | Can view style type
+  

--- a/qgis-app/styles/templates/styles/style_review.html
+++ b/qgis-app/styles/templates/styles/style_review.html
@@ -59,7 +59,7 @@
                     {% endwith %}
                 {% endif %}
 
-                {% if user.is_staff %}
+                {% if form %}
                 <form method="post" action="{% url 'style_review' pk=style_detail.id %}">{% csrf_token %}
                     <dt>Approval</dt>
                     <dd>

--- a/qgis-app/styles/tests/test_views.py
+++ b/qgis-app/styles/tests/test_views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.contrib.auth.models import User, Group
 
 from styles.models import Style, StyleType
-from styles.views import style_approval_notify, style_notify
+from styles.views import style_update_notify, style_notify
 
 STYLE_DIR = os.path.join(os.path.dirname(__file__), "stylefiles")
 
@@ -310,7 +310,7 @@ class TestStyleApprovalNotify(TestCase):
                       mail.outbox[0].body)
 
     def test_send_email_approved_style_notification(self):
-        style_approval_notify(self.style_approved, self.creator, self.staff)
+        style_update_notify(self.style_approved, self.creator, self.staff)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject,
                          "Style Cube approved notification.")
@@ -318,7 +318,7 @@ class TestStyleApprovalNotify(TestCase):
                       mail.outbox[0].body)
 
     def test_send_email_rejected_style_notification(self):
-        style_approval_notify(self.style_rejected, self.creator, self.staff)
+        style_update_notify(self.style_rejected, self.creator, self.staff)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject,
                          "Style Another Cube rejected notification.")

--- a/qgis-app/styles/views.py
+++ b/qgis-app/styles/views.py
@@ -1,9 +1,13 @@
 import json
+import logging
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.models import User
 from django.core import serializers
+from django.contrib.sites.models import Site
+from django.core.mail import send_mail
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render
@@ -26,25 +30,105 @@ from styles.forms import (StyleUploadForm,
 from styles.file_handler import read_xml_style
 
 
-def check_styles_access(user, style):
+def is_style_manager(user: User) -> bool:
+    """Check if user is the members of Style Managers group."""
+
+    return user.groups.filter(name="Style Managers").exists()
+
+
+def check_styles_access(user: User, style: Style) -> bool:
+    """Check if user is the creator of the style or is_staff."""
+
+    return user.is_staff or style.creator == user or is_style_manager(user)
+
+
+def send_mail_wrapper(subject,
+                      message,
+                      mail_from,
+                      recipients,
+                      fail_silently=True):
     """
-    Check if user is the creator of the style or is_staff
-
-    Parameters
-    ----------
-    user : User instance
-        The user whom will be checked against the style
-    style : Style instance
-
-    Returns
-    -------
-    bool
-        Return True if user is_staff or user is style's creator
+    Wrapping send_email function to send email only when not DEBUG.
     """
 
-    if user.is_staff or style.creator == user:
-        return True
-    return False
+    if settings.DEBUG:
+        logging.debug("Mail not sent (DEBUG=True)")
+    else:
+        send_mail(subject,
+                  message,
+                  mail_from,
+                  recipients,
+                  fail_silently)
+
+
+def style_notify(style: Style, created=True) -> None:
+    """
+    Email notification when a new style created.
+
+    """
+    recipients = [u.email for u in User.objects.filter(
+        groups__name="Style Managers").exclude(email='')]
+
+    if created:
+        style_status = "created"
+    else:
+        style_status = "updated"
+
+    if recipients:
+        domain = Site.objects.get_current().domain
+        mail_from = settings.DEFAULT_FROM_EMAIL
+
+        send_mail_wrapper(
+            _('A new style has been %s by %s.') % (style_status,
+                                                   style.creator),
+            _('\r\nStyle name is: %s\r\nStyle description is: %s\r\n'
+              'Link: http://%s%s\r\n') % (style.name, style.description,
+                                          domain, style.get_absolute_url()),
+            mail_from,
+            recipients,
+            fail_silently=True)
+        logging.debug('Sending email notification for %s style, '
+                      'recipients:  %s' % (style.name, recipients))
+    else:
+        logging.warning('No recipients found for %s style notification'
+                        % style.name)
+
+
+def style_approval_notify(style: Style, creator: User, staff: User) -> None:
+    """
+    Email notification system for approval styles
+    """
+
+    recipients = [u.email for u in User.objects.filter(
+        groups__name="Style Managers").exclude(email='')]
+
+    if creator.email:
+        recipients += [creator.email]
+
+    if style.approved:
+        approval_state = 'approved'
+    else:
+        approval_state = 'rejected'
+
+    review = style.stylereview_set.last()
+    comment = review.comment
+
+    if recipients:
+        domain = Site.objects.get_current().domain
+        mail_from = settings.DEFAULT_FROM_EMAIL
+        send_mail_wrapper(
+          _('Style %s %s notification.') % (style, approval_state),
+          _('\r\nStyle %s %s by %s.\r\n%s\r\nLink: http://%s%s\r\n') % (
+              style.name, approval_state, staff, comment, domain,
+              style.get_absolute_url()),
+          mail_from,
+          recipients,
+          fail_silently=True)
+        logging.debug('Sending email %s notification for %s style, '
+                      'recipients:  %s' % (approval_state, style, recipients))
+    else:
+        logging.warning('No recipients found for %s style %s notification' % (
+            style, approval_state))
 
 
 class StyleCreateView(LoginRequiredMixin, CreateView):
@@ -79,6 +163,7 @@ class StyleCreateView(LoginRequiredMixin, CreateView):
                                 "'an uploaded Style file")
             obj.style_type = style_type
         obj.save()
+        style_notify(obj)
         msg = _("The Style has been successfully created.")
         messages.success(self.request, msg, 'success', fail_silently=True)
         return HttpResponseRedirect(reverse('style_detail',
@@ -157,7 +242,7 @@ class StyleUnapprovedListView(LoginRequiredMixin, StyleListView):
     def get_queryset(self):
         qs = super().get_queryset()
         user = self.request.user
-        if user.is_staff:
+        if user.is_staff or is_style_manager(user):
             return qs
         return qs.filter(creator=user)
 
@@ -174,7 +259,7 @@ class StyleRequireActionListView(LoginRequiredMixin, StyleListView):
     def get_queryset(self):
         qs = super().get_queryset()
         user = self.request.user
-        if user.is_staff:
+        if user.is_staff or is_style_manager(user):
             return qs
         return qs.filter(creator=user)
 
@@ -197,9 +282,10 @@ class StyleDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
+        user = self.request.user
         if self.object.creator.first_name:
-            creator = "%s %s" % (self.object.creator.first_name,
-                self.object.creator.first_name)
+            creator = "%s %s" % (
+                self.object.creator.first_name, self.object.creator.first_name)
         else:
             creator = self.object.creator.username
         context['creator'] = creator
@@ -212,7 +298,7 @@ class StyleDetailView(DetailView):
                 reviewer = self.object.stylereview_set.last().reviewer \
                     .username
             context['reviewer'] = reviewer
-        if self.request.user.is_staff:
+        if user.is_staff or is_style_manager(user):
             context['form'] = StyleReviewForm()
         return context
 
@@ -232,8 +318,8 @@ class StyleUpdateView(LoginRequiredMixin, UpdateView):
         user = self.request.user
         if not check_styles_access(user, style):
             return render(request, 'styles/style_permission_deny.html',
-                {'style_name': style.name,
-                 'context': "You cannot modify this style"})
+                          {'style_name': style.name,
+                           'context': "You cannot modify this style"})
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
@@ -244,10 +330,12 @@ class StyleUpdateView(LoginRequiredMixin, UpdateView):
         obj = form.save(commit=False)
         xml_parse = read_xml_style(obj.xml_file)
         if xml_parse:
-            obj.style_type = StyleType.objects \
-                .filter(symbol_type=xml_parse['type']).first()
+            obj.style_type = StyleType.objects.filter(
+                symbol_type=xml_parse['type']).first()
         obj.require_action = False
+        obj.approved = False
         obj.save()
+        style_notify(obj, created=False)
         msg = _("The Style has been successfully updated.")
         messages.success(self.request, msg, 'success', fail_silently=True)
         return HttpResponseRedirect(reverse_lazy('style_detail',
@@ -269,7 +357,8 @@ class StyleDeleteView(LoginRequiredMixin, DeleteView):
         style = self.get_object()
         user = self.request.user
         if not check_styles_access(user, style):
-            return render(request, 'styles/style_permission_deny.html',
+            return render(
+                request, 'styles/style_permission_deny.html',
                 {'style_name': style.name,
                  'context': "You cannot delete this style"})
         return super().dispatch(request, *args, **kwargs)
@@ -283,7 +372,8 @@ def style_download(request, pk):
     style = get_object_or_404(Style, pk=pk)
     if not style.approved:
         if not check_styles_access(request.user, style):
-            return render(request, 'styles/style_permission_deny.html',
+            return render(
+                request, 'styles/style_permission_deny.html',
                 {'style_name': style.name,
                  'context': 'Download failed. This style is not approved'})
     else:
@@ -300,7 +390,7 @@ def style_download(request, pk):
 
 def style_review(request, pk):
     """
-    Submit a style review
+    Submit a style review and send email notification
     """
 
     style = get_object_or_404(Style, pk=pk)
@@ -323,6 +413,8 @@ def style_review(request, pk):
                 msg = _("The Style has been rejected.")
                 messages.success(request, msg, 'error', fail_silently=True)
             style.save()
+            # send email notification
+            style_approval_notify(style, style.creator, request.user)
     return HttpResponseRedirect(reverse('style_detail', kwargs={'pk': pk}))
 
 
@@ -333,18 +425,18 @@ def style_nav_content(request):
     """
 
     user = request.user
-    all = Style.approved_objects.count()
+    all_styles = Style.approved_objects.count()
     waiting_review = 0
     require_action = 0
-    if user.is_staff:
+    if user.is_staff or is_style_manager(user):
         waiting_review = Style.unapproved_objects.distinct().count()
         require_action = Style.requireaction_objects.distinct().count()
     elif user.is_authenticated:
-        waiting_review = Style.unapproved_objects.filter(creator=user) \
-            .distinct().count()
-        require_action = Style.requireaction_objects.filter(creator=user) \
-            .distinct().count()
-    number_style = {'all': all,
+        waiting_review = Style.unapproved_objects.filter(
+            creator=user).distinct().count()
+        require_action = Style.requireaction_objects.filter(
+            creator=user).distinct().count()
+    number_style = {'all': all_styles,
                     'waiting_review': waiting_review,
                     'require_action': require_action}
     return JsonResponse(number_style, status=200)

--- a/qgis-app/styles/views.py
+++ b/qgis-app/styles/views.py
@@ -94,7 +94,7 @@ def style_notify(style: Style, created=True) -> None:
                         % style.name)
 
 
-def style_approval_notify(style: Style, creator: User, staff: User) -> None:
+def style_update_notify(style: Style, creator: User, staff: User) -> None:
     """
     Email notification system for approval styles
     """
@@ -414,7 +414,7 @@ def style_review(request, pk):
                 messages.success(request, msg, 'error', fail_silently=True)
             style.save()
             # send email notification
-            style_approval_notify(style, style.creator, request.user)
+            style_update_notify(style, style.creator, request.user)
     return HttpResponseRedirect(reverse('style_detail', kwargs={'pk': pk}))
 
 


### PR DESCRIPTION
@timlinux @dimasciput 

This PR refers to #106. It does:

- send email notification to **staff** when there's a new style created.
- send email notification to **staff** when there's a style updated.
- send email notification to **creator** when the styles has been reviewed (approved/ rejected).
- include unit test for `style_notify` and `style_approval_notify` function alone.
 
the updated style will require a review from staff. 