### PR TITLE
Raise validationError if zipfile contains '__MACOSX' folder

### DIFF
--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -80,8 +80,11 @@ def validator(package):
     for zname in zip.namelist():
         if zname.find('..') != -1 or zname.find(os.path.sep) == 0 :
             raise ValidationError( _("For security reasons, zip file cannot contain path informations") )
-        if zname.find('__MACOSX') != -1:
-            raise ValidationError( _("For security reasons, zip file cannot contain '__MACOSX' folder") )
+        for not_allowed_dir in ['__MACOSX', '.git', '__pycache__']:
+            if zname.find(not_allowed_dir) != -1:
+                raise ValidationError(_("For security reasons, zip file "
+                                        "cannot contain '%s' directory"
+                                        % (not_allowed_dir,)) )
     bad_file = zip.testzip()
     if bad_file:
         zip.close()

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -80,6 +80,8 @@ def validator(package):
     for zname in zip.namelist():
         if zname.find('..') != -1 or zname.find(os.path.sep) == 0 :
             raise ValidationError( _("For security reasons, zip file cannot contain path informations") )
+        if zname.find('__MACOSX') != -1:
+            raise ValidationError( _("For security reasons, zip file cannot contain '__MACOSX' folder") )
     bad_file = zip.testzip()
     if bad_file:
         zip.close()


### PR DESCRIPTION
@timlinux @dimasciput 

This PR refers to #62. It does:
- raise ValidationError when zipfile contains '__MACOSX' folder

![plugins_62_macosx_folder](https://user-images.githubusercontent.com/40058076/100403177-1e374400-3099-11eb-885e-2e75d20e0bb9.gif)

The zipfile uploaded on the gif animations above contains:
```
suman@NUC10:~/Desktop$ tree -L 1 dummyzip
dummyzip
├── core
├── dummyzip.py
├── gui
├── help
├── i18n
├── icons
├── __init__.py
├── libs
├── __MACOSX
├── metadata.txt
├── resources.py
├── ui
└── utils
```
