### PR TITLE
upgrade django version based on CVE's message

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,4 +1,4 @@
-Django==1.8.2
+Django==1.11.29
 # Currently broken with 'no module named defaults' error
 #Feedjack==0.9.18
 # So use George's fork rather

--- a/dockerize/docker/REQUIREMENTS.txt
+++ b/dockerize/docker/REQUIREMENTS.txt
@@ -1,4 +1,4 @@
-django==2.2
+django==2.2.13
 django-auth-ldap
 python-ldap
 django-taggit

--- a/qgis-app/REQUIREMENTS_plugins.txt
+++ b/qgis-app/REQUIREMENTS_plugins.txt
@@ -1,4 +1,4 @@
-django==2.2
+django==2.2.13
 django-auth-ldap
 python-ldap
 django-taggit


### PR DESCRIPTION
@timlinux @dimasciput 
This PR refers to #61 an #67. It does upgrade django version based on Dependabot alerts.

I upgraded django version from 2.2 to 2.2.13 in localmachine, and it's running well so far, run unit test and it passed the test successfully.