### PR TITLE
show larger style icon when hover and change detail view span4 layout

### DIFF
--- a/qgis-app/styles/templates/styles/style_detail.html
+++ b/qgis-app/styles/templates/styles/style_detail.html
@@ -10,7 +10,7 @@
         {% endif %}
         <hr />
         <div class="row">
-            <div class="span6 mb-5">
+            <div class="span4 mb-5">
                 <div class="style-polaroid">
                     {% thumbnail style_detail.thumbnail_image "420x420" format="PNG" as im %}
                     <img class="" alt="{% trans "Style icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
@@ -19,7 +19,7 @@
                 </div>
 
             </div>
-            <div class="span6">
+            <div class="span8">
                 <dl class="dl-horizontal">
                     <dd></dd>
                     <dt>Name</dt>

--- a/qgis-app/styles/templates/styles/style_list.html
+++ b/qgis-app/styles/templates/styles/style_list.html
@@ -13,6 +13,31 @@
     .sorted-name {
         color: #006dcc;
     }
+
+    table > tbody > tr {
+        height: 120px;
+    }
+
+    .table td {
+        vertical-align: middle;
+    }
+
+    img.style-icon {
+        width: 100px;
+        height: 100px;
+    }
+
+    img.style-icon:hover {
+        width: 320px;
+        height: 320px;
+        position: absolute;
+
+        margin-top: -250px;
+        margin-left: -220px;
+        border-radius: 20px;
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+
+    }
 </style>
 {% endblock %}
 
@@ -51,12 +76,12 @@
             {% for style in style_list %}
                 <tr>
                     <td>
-                        {% thumbnail style.thumbnail_image "32x32" format="PNG" as im %}
-                            <img class="plugin-icon" alt="{% trans "Style icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
+                        {% thumbnail style.thumbnail_image "420x420" format="PNG" as im %}
+                            <img class="style-icon" alt="{% trans "Style icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
                         {% endthumbnail %}
                     </td>
                     <td><a href="{% url 'style_detail' style.id %}">{{ style.name|title }}</a></td>
-                    <td>{{ style.style_type.name|title }}</td>
+                    <td><span class="center-vertical">{{ style.style_type.name|title }}</span></td>
                     <td>{{ style.download_count }}</td>
                     <td>{{ style.get_creator_name|title }}</td>
                     <td>{{ style.upload_date|date:"d F Y" }}</td>


### PR DESCRIPTION
@dimasciput 
This PR refers to #123 and #126. It does:
- show larger icon styles when hovering over it
- change image class to `span4`

![plugins_geopackages_icon5](https://user-images.githubusercontent.com/40058076/101128160-08e28c80-363a-11eb-9808-bc9ba1a9ce7e.gif)
