### PR TITLE
fix minor layout style template

### DIFF
--- a/qgis-app/styles/templates/styles/style_base.html
+++ b/qgis-app/styles/templates/styles/style_base.html
@@ -7,9 +7,10 @@
 {% block extrajs %}
     <style>
         div.style-polaroid{
-            width: 420px;
+            width: 100%;
             box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
             text-align: center;
+            margin-top: 23px;
         }
         div.style-polaroid {
             margin-left: 1em;


### PR DESCRIPTION
@dimasciput @timlinux 

This PR fix responsive layout for styles detail view. Recently the detail info grid will overlap with image when push against it.

![plugins_styles_fix_minor_layout1](https://user-images.githubusercontent.com/40058076/101307388-49344b80-3882-11eb-814f-0d13ed417327.gif)

This PR does: 
- change css class of image grid so that the image and info description will not overlap
![plugins_styles_fix_minor_layout](https://user-images.githubusercontent.com/40058076/101306987-54d34280-3881-11eb-9a28-003210c4b317.gif)
