### PR TITLE
Set FILE_UPLOAD_PERMISSIONS in settings

### DIFF
--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -99,3 +99,6 @@ EMAIL_HOST_USER = 'noreply'
 EMAIL_HOST_PASSWORD = 'docker'
 EMAIL_USE_TLS = False
 EMAIL_SUBJECT_PREFIX = '[QGIS Plugins]'
+
+# django uploaded file permission
+FILE_UPLOAD_PERMISSIONS = 0o644


### PR DESCRIPTION
@dimasciput @timlinux 
This PR refers to #112. It does set permission of newly uploaded files to 644,  so that it will not depend on operating-system behavior.