### PR TITLE
fix updated plugins list query manager

### DIFF
--- a/qgis-app/plugins/models.py
+++ b/qgis-app/plugins/models.py
@@ -13,7 +13,7 @@ from djangoratings.fields import AnonymousRatingField
 from taggit_autosuggest.managers import TaggableManager
 
 PLUGINS_STORAGE_PATH = getattr(settings, 'PLUGINS_STORAGE_PATH', 'packages/%Y')
-PLUGINS_FRESH_DAYS = getattr(settings, 'PLUGINS_FRESH_DAYS', 7)
+PLUGINS_FRESH_DAYS = getattr(settings, 'PLUGINS_FRESH_DAYS', 30)
 
 
 # Used in Version fields to transform DB value back to human readable string
@@ -111,7 +111,8 @@ class LatestPlugins(BasePluginManager):
         return super(LatestPlugins, self).get_queryset().filter(
             deprecated=False,
             pluginversion__approved=True,
-            modified_on__gte=datetime.datetime.now() - datetime.timedelta(days=self.days)
+            pluginversion__created_on__gte=(
+                datetime.datetime.now() - datetime.timedelta(days=self.days))
         ).order_by('-latest_version_date').distinct()
 
 


### PR DESCRIPTION
@dimasciput @timlinux  @agiudiceandrea 

This PR refers to https://github.com/qgis/QGIS-Django/pull/115#issuecomment-741078012

It does:
- change queryset filter for Updated plugins from plugins modifed date to version created date.
- change queryset for New plugins and updated plugins, so that show the plugins affected within 30 days
![82_latest_fresh_3](https://user-images.githubusercontent.com/40058076/101707530-6194a800-3ac6-11eb-994e-470c5a1e837c.png)
![82_latest_fresh_4](https://user-images.githubusercontent.com/40058076/101707538-63f70200-3ac6-11eb-91d1-e65ac4ad14ed.png)

