### PR TITLE
remove automatic title case in gpkg

### DIFF
--- a/qgis-app/geopackages/templates/geopackages/geopackage_detail.html
+++ b/qgis-app/geopackages/templates/geopackages/geopackage_detail.html
@@ -1,7 +1,7 @@
 {% extends 'geopackages/geopackage_base.html' %}{% load i18n static thumbnail resources_custom_tags%}
 
 {% block content %}
-        <h3 class="style-title">{{ geopackage_detail.name|title }}</h3>
+        <h3 class="style-title">{{ geopackage_detail.name }}</h3>
         {% if user == geopackage_detail.creator or user.is_staff %}
         <div class="row pull-right">
             <a class="btn btn-primary btn-mini" href="{% url 'geopackage_update' geopackage_detail.id %}" title="{% trans "Edit" %}"><i class="icon-pencil icon-white"></i></a>&nbsp

--- a/qgis-app/geopackages/templates/geopackages/geopackage_list.html
+++ b/qgis-app/geopackages/templates/geopackages/geopackage_list.html
@@ -59,7 +59,7 @@
                         <img height="32" width="32" class="plugin-icon" src="{% static "images/qgis-icon-32x32.png" %}" alt="{% trans "Plugin icon" %}" />
                     {% endif %}
                     </td>
-                    <td><a href="{% url 'geopackage_detail' pk=geopackage.id %}">{{ geopackage.name|title }}</a></td>
+                    <td><a href="{% url 'geopackage_detail' pk=geopackage.id %}">{{ geopackage.name}}</a></td>
                     <td>{{ geopackage.description|md_to_html|striptags|truncatewords:7 }}</a></td>
                     <td>{{ geopackage.download_count }}</td>
                     <td>{{ geopackage.get_creator_name|title }}</td>

--- a/qgis-app/geopackages/templates/geopackages/geopackage_review.html
+++ b/qgis-app/geopackages/templates/geopackages/geopackage_review.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block content %}
-    <h3>{{ geopackage_detail.name|title }} <small>in review</small></h3>
+    <h3>{{ geopackage_detail.name }} <small>in review</small></h3>
     {% if user == geopackage_detail.creator or user.is_staff %}
         <div class="row pull-right">
             <a class="btn btn-primary btn-mini" href="{% url 'geopackage_update' geopackage_detail.id %}" title="{% trans "Edit" %}"><i class="icon-pencil icon-white"></i></a>&nbsp

--- a/qgis-app/geopackages/tests/test_views.py
+++ b/qgis-app/geopackages/tests/test_views.py
@@ -268,4 +268,4 @@ class TestReviewGeopackage(SetUpTest, TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "1 record found.")
-        self.assertContains(response, "Spiky Polygons")
+        self.assertContains(response, "spiky polygons")


### PR DESCRIPTION
@timlinux @dimasciput 

This PR refers to #137. It does:
- remove automatic title case in list view projects' page
- remove automatic title case in detail view projects' page
- remove automatic title case in review projects' page
![137_auto_title](https://user-images.githubusercontent.com/40058076/102031998-a2f0c480-3df2-11eb-92d6-9598d0ef89a7.png)
![137_auto_title0](https://user-images.githubusercontent.com/40058076/102032000-a421f180-3df2-11eb-94e8-477090f11a81.png)
![137_auto_title1](https://user-images.githubusercontent.com/40058076/102032003-a5531e80-3df2-11eb-8709-095623725cf5.png)
