### PR TITLE
State CC-0 license on detail page

### DIFF
--- a/qgis-app/geopackages/templates/geopackages/geopackage_base.html
+++ b/qgis-app/geopackages/templates/geopackages/geopackage_base.html
@@ -7,11 +7,12 @@
 {% block extrajs %}
     <style>
         div.style-polaroid{
-            width: 420px;
+            width: 100%;
             box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
             text-align: center;
+            margin-top: 23px;
         }
-        div.style-polaroid {
+        div.style-polaroid, div.span12.license {
             margin-left: 1em;
         }
         .style-title {

--- a/qgis-app/geopackages/templates/geopackages/geopackage_detail.html
+++ b/qgis-app/geopackages/templates/geopackages/geopackage_detail.html
@@ -10,7 +10,7 @@
         {% endif %}
         <hr />
         <div class="row">
-            <div class="span6 mb-5">
+            <div class="span4 mb-5">
                 <div class="style-polaroid">
                     {% thumbnail geopackage_detail.thumbnail_image "420x420" format="PNG" as im %}
                     <img class="" alt="{% trans "GeoPackage image" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
@@ -19,7 +19,7 @@
                 </div>
 
             </div>
-            <div class="span6">
+            <div class="span8">
                 <dl class="dl-horizontal">
                     <dd></dd>
                     <dt>Name</dt>
@@ -41,7 +41,16 @@
                 </dl>
 
             </div>
-            <div class="span12"></div>
+            <div class="span12 license">
+              <div class="media" style="margin-top: 2rem">
+                <a class="pull-left" href="#">
+                  <img src="{% static 'images/cc-zero.svg' %}">
+                </a>
+                <div class="media-body">
+                  <p>This GeoPackage is made available under the <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank">CC-0 license</a>.</p>
+                </div>
+              </div>
+            </div>
 
         </div>
 {% endblock %}

--- a/qgis-app/models/templates/models/model_base.html
+++ b/qgis-app/models/templates/models/model_base.html
@@ -7,11 +7,12 @@
 {% block extrajs %}
     <style>
         div.style-polaroid{
-            width: 420px;
+            width: 100%;
             box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
             text-align: center;
+            margin-top: 23px;
         }
-        div.style-polaroid {
+        div.style-polaroid, div.span12.license {
             margin-left: 1em;
         }
         .style-title {

--- a/qgis-app/models/templates/models/model_detail.html
+++ b/qgis-app/models/templates/models/model_detail.html
@@ -10,7 +10,7 @@
         {% endif %}
         <hr />
         <div class="row">
-            <div class="span6 mb-5">
+            <div class="span4 mb-5">
                 <div class="style-polaroid">
                     {% thumbnail model_detail.thumbnail_image "420x420" format="PNG" as im %}
                     <img class="" alt="{% trans "Model image" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
@@ -19,7 +19,7 @@
                 </div>
 
             </div>
-            <div class="span6">
+            <div class="span8">
                 <dl class="dl-horizontal">
                     <dd></dd>
                     <dt>Name</dt>
@@ -41,7 +41,16 @@
                 </dl>
 
             </div>
-            <div class="span12"></div>
+            <div class="span12 license">
+              <div class="media" style="margin-top: 2rem">
+                <a class="pull-left" href="#">
+                  <img src="{% static 'images/cc-zero.svg' %}">
+                </a>
+                <div class="media-body">
+                  <p>This Model is made available under the <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank">CC-0 license</a>.</p>
+                </div>
+              </div>
+            </div>
 
         </div>
 {% endblock %}

--- a/qgis-app/styles/templates/styles/style_base.html
+++ b/qgis-app/styles/templates/styles/style_base.html
@@ -12,7 +12,7 @@
             text-align: center;
             margin-top: 23px;
         }
-        div.style-polaroid {
+        div.style-polaroid, div.span12.license {
             margin-left: 1em;
         }
         .style-title {

--- a/qgis-app/styles/templates/styles/style_detail.html
+++ b/qgis-app/styles/templates/styles/style_detail.html
@@ -46,7 +46,17 @@
                 </dl>
 
             </div>
-            <div class="span12"></div>
+            <div class="span12 license">
+              <div class="media" style="margin-top: 2rem">
+                <a class="pull-left" href="#">
+                  <img src="{% static 'images/cc-zero.svg' %}">
+                </a>
+                <div class="media-body">
+                  <p>This Style is made available under the <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank">CC-0 license</a>.</p>
+                </div>
+              </div>
+            </div>
+
 
         </div>
 {% endblock %}


### PR DESCRIPTION
@nyalldawson @timlinux @dimasciput 

This PR refers to https://github.com/qgis/QGIS-Django/issues/142#issuecomment-751887991. It does:
- add icon cc-0
- state that the item is under cc-0 license with link to https://creativecommons.org/publicdomain/zero/1.0/
- fix minor css style

![142_license_detail](https://user-images.githubusercontent.com/40058076/103264118-bb610180-49e4-11eb-9a79-1ec6d835b720.png)
