### PR TITLE
change github repo link on footer

### DIFF
--- a/qgis-app/static/style/new/qgis-style.css
+++ b/qgis-app/static/style/new/qgis-style.css
@@ -266,9 +266,6 @@ select#languages option {
 .footer #facebook {
     background: url("images/footer-facebook.png") no-repeat scroll 0 0 transparent;
 }
-.footer #gplus {
-    background: url("images/footer-gplus.png") no-repeat scroll 0 0 transparent;
-}
 .footer #github {
     background: url("images/footer-github.png") no-repeat scroll 0 0 transparent;
 }

--- a/qgis-app/templates/base.html
+++ b/qgis-app/templates/base.html
@@ -129,7 +129,7 @@
                 <div>
                   <ul class="unstyled inline" id="social">
                     <li id="twitter"><a href="http://twitter.com/qgis" class="external"><div></div></a></li>
-                    <li id="facebook"><a href="https://www.facebook.com/pages/QGIS-Quantum-GIS-/298112000235096" class="external"><div></div></a></li>
+                    <li id="facebook"><a href="https://www.facebook.com/QGIS-298112000235096" class="external"><div></div></a></li>
                     <li id="github"><a href="http://github.com/qgis/QGIS-Django" class="external"><div></div></a></li>
                   </ul>
                 </div>

--- a/qgis-app/templates/base.html
+++ b/qgis-app/templates/base.html
@@ -130,10 +130,9 @@
                   <ul class="unstyled inline" id="social">
                     <li id="twitter"><a href="http://twitter.com/qgis" class="external"><div></div></a></li>
                     <li id="facebook"><a href="https://www.facebook.com/pages/QGIS-Quantum-GIS-/298112000235096" class="external"><div></div></a></li>
-                    <li id="gplus"><a href="http://plus.google.com/communities/114776597176808981624" class="external"><div></div></a></li>
                     <li id="github"><a href="http://github.com/qgis/QGIS-Django" class="external"><div></div></a></li>
                   </ul>
-                </div>q
+                </div>
 
                 <p class="credit">{% trans "All content is licensed under" %} <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 licence (CC BY-SA)</a>.</p>
             </div>

--- a/qgis-app/templates/base.html
+++ b/qgis-app/templates/base.html
@@ -131,9 +131,9 @@
                     <li id="twitter"><a href="http://twitter.com/qgis" class="external"><div></div></a></li>
                     <li id="facebook"><a href="https://www.facebook.com/pages/QGIS-Quantum-GIS-/298112000235096" class="external"><div></div></a></li>
                     <li id="gplus"><a href="http://plus.google.com/communities/114776597176808981624" class="external"><div></div></a></li>
-                    <li id="github"><a href="http://github.com/qgis/" class="external"><div></div></a></li>
+                    <li id="github"><a href="http://github.com/qgis/QGIS-Django" class="external"><div></div></a></li>
                   </ul>
-                </div>
+                </div>q
 
                 <p class="credit">{% trans "All content is licensed under" %} <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 licence (CC BY-SA)</a>.</p>
             </div>


### PR DESCRIPTION
This PR refers to #149. It does:
- change the github repo link embed in github icon to https://github.com/qgis/QGIS-Django

![image](https://user-images.githubusercontent.com/40058076/105336189-e7eaf080-5c13-11eb-8d6f-600c45446a9f.png)
