### PR TITLE
Fix url validator

### DIFF
--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -81,7 +81,15 @@ def _check_url_link(url: str, forbidden_url: str, metadata_attr: str) -> None:
 
     # Check if url is exist
     try:
-        req = requests.head(url)
+        # https://stackoverflow.com/a/41950438/10268058
+        # add the headers parameter to make the request appears like coming
+        # from browser, otherwise some websites will return 403
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) '
+                          'AppleWebKit/537.36 (KHTML, like Gecko) '
+                          'Chrome/56.0.2924.76 Safari/537.36'
+        }
+        req = requests.head(url, headers=headers)
     except requests.exceptions.SSLError:
         req = requests.head(url, verify=False)
     except Exception:


### PR DESCRIPTION
There's an issue occurred during plugin upload. It returns error for the url validation, even though the url works in browser.

In this PR, we add the headers parameter in the request to make the request appears like coming from browser (not from non-browser).