### PR TITLE
fix xml create and update date

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugins.xml
+++ b/qgis-app/plugins/templates/plugins/plugins.xml
@@ -14,8 +14,8 @@
         <author_name><![CDATA[{% firstof version.plugin.author version.plugin.created_by %}]]></author_name>
         <download_url>{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.get_host }}{{ version.get_download_url }}</download_url>
         <uploaded_by><![CDATA[{{ version.created_by }}]]></uploaded_by>
-        <create_date>{{ version.created_on.isoformat }}</create_date>
-        <update_date>{{ version.plugin.modified_on.isoformat }}</update_date>
+        <create_date>{{ version.plugin.created_on.isoformat }}</create_date>
+        <update_date>{{ version.created_on.isoformat }}</update_date>
         <experimental>{% if version.experimental %}True{% else%}False{% endif %}</experimental>
         <deprecated>{{ version.plugin.deprecated }}</deprecated>
         <tracker><![CDATA[{{ version.plugin.tracker }}]]></tracker>


### PR DESCRIPTION
please see #188 

test on local:
![image](https://user-images.githubusercontent.com/40058076/135597735-02d1d8f6-6984-4b51-bd46-6dab1a94e6fc.png)


<pyqgis_plugin name="3D City Builder" version="0.3" plugin_id="2176">
 <create_date>2020-10-07T14:35:46.141014</create_date>
 <update_date>2021-07-06T05:17:29.223092</update_date>

</pyqgis_plugin><pyqgis_plugin name="A-Maps" version="0.2" plugin_id="1726">
<create_date>2019-05-25T08:06:51.184187</create_date>
<update_date>2019-05-30T14:27:48.790339</update_date>
