### PR TITLE
updated lxml version

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -36,7 +36,7 @@ django-taggit-templatetags==0.4.6dev0
 django-templatetag-sugar==0.1
 django-tinymce==1.5.2
 feedparser==5.1.3
-lxml==4.6.2
+lxml==4.6.3
 opml==0.5
 psycopg2==2.5.1
 python-ldap==2.4.19


### PR DESCRIPTION
This PR is to address lxml CVE-2021-28957.

Please be noted that in the dockerize version, we are using `defusedxml` instead of `lxml`
\cc @dimasciput 