### PR TITLE
Fix min_qg_version query in plugins.xml

### DIFF
--- a/qgis-app/plugins/tests/test_view.py
+++ b/qgis-app/plugins/tests/test_view.py
@@ -8,20 +8,20 @@ class TestTruncateVersion(TestCase):
 
     def test__add_patch_version_with_3_segment_version_number(self):
         version = '1.2.'
-        self.assertEqual(_add_patch_version(version), '1.2.99')
+        self.assertEqual(_add_patch_version(version, '0'), '1.2.0')
 
     def test__add_patch_version_with_2_segment_version_number(self):
         version = '1.2'
-        self.assertEqual(_add_patch_version(version), '1.2.99')
+        self.assertEqual(_add_patch_version(version, '99'), '1.2.99')
 
     def test__add_patch_version_with_1_segment_version_number(self):
         version = '1'
-        self.assertEqual(_add_patch_version(version), '1')
+        self.assertEqual(_add_patch_version(version, '99'), '1')
 
     def test__add_patch_version_with_None(self):
         version = None
-        self.assertEqual(_add_patch_version(version), None)
+        self.assertEqual(_add_patch_version(version, '99'), None)
 
     def test__add_patch_version_with_empty_string(self):
         version = ''
-        self.assertEqual(_add_patch_version(version), '')
+        self.assertEqual(_add_patch_version(version, '99'), '')

--- a/qgis-app/plugins/tests/test_view.py
+++ b/qgis-app/plugins/tests/test_view.py
@@ -7,12 +7,12 @@ class TestTruncateVersion(TestCase):
     """Test _add_patch_version function"""
 
     def test__add_patch_version_with_3_segment_version_number(self):
-        version = '1.2.'
-        self.assertEqual(_add_patch_version(version, '0'), '1.2.0')
+        version = '1.2.3'
+        self.assertEqual(_add_patch_version(version, '99'), '1.2.3')
 
     def test__add_patch_version_with_2_segment_version_number(self):
         version = '1.2'
-        self.assertEqual(_add_patch_version(version, '99'), '1.2.99')
+        self.assertEqual(_add_patch_version(version, '00'), '1.2.00')
 
     def test__add_patch_version_with_1_segment_version_number(self):
         version = '1'

--- a/qgis-app/plugins/tests/test_view.py
+++ b/qgis-app/plugins/tests/test_view.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+
+from plugins.views import _add_patch_version
+
+
+class TestTruncateVersion(TestCase):
+    """Test _add_patch_version function"""
+
+    def test__add_patch_version_with_3_segment_version_number(self):
+        version = '1.2.'
+        self.assertEqual(_add_patch_version(version), '1.2.99')
+
+    def test__add_patch_version_with_2_segment_version_number(self):
+        version = '1.2'
+        self.assertEqual(_add_patch_version(version), '1.2.99')
+
+    def test__add_patch_version_with_1_segment_version_number(self):
+        version = '1'
+        self.assertEqual(_add_patch_version(version), '1')
+
+    def test__add_patch_version_with_None(self):
+        version = None
+        self.assertEqual(_add_patch_version(version), None)
+
+    def test__add_patch_version_with_empty_string(self):
+        version = ''
+        self.assertEqual(_add_patch_version(version), '')

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -916,7 +916,7 @@ def _add_patch_version(version: str, additional_patch: str ) -> str:
         return version
     separator = '.'
     v = version.split(separator)
-    if len(v) > 1:
+    if len(v) == 2:
         two_first_segment = separator.join(v[:2])
         version = f'{two_first_segment}.{additional_patch}'
     return version

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -903,6 +903,26 @@ def version_detail(request, package_name, version):
 from django.views.decorators.cache import cache_page
 
 
+def _add_patch_version(version: str) -> str:
+    """To add patch number in version.
+
+    e.g qgis version = 3.16 we add patch number (99) in versioning -> 3.16.99
+    We use this versioning to query against PluginVersion min_qg_version,
+    so that the query result will include all PluginVersion with
+    minimum QGIS version 3.16 regardless of the patch number.
+    """
+
+    if not version:
+        return version
+    separator = '.'
+    v = version.split(separator)
+    if len(v) > 1:
+        two_first_segment = separator.join(v[:2])
+        max_patch_version = 99
+        version = f'{two_first_segment}.{max_patch_version}'
+    return version
+
+
 @cache_page(60 * 15)
 def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
     """
@@ -924,8 +944,8 @@ def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
     object_list = []
 
     if qg_version:
-        filters.update({'pluginversion__min_qg_version__lte' : qg_version})
-        version_filters.update({'min_qg_version__lte' : qg_version})
+        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version)})
+        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version)})
         filters.update({'pluginversion__max_qg_version__gte' : qg_version})
         version_filters.update({'max_qg_version__gte' : qg_version})
 
@@ -1001,8 +1021,8 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
     object_list = []
 
     if qg_version:
-        filters.update({'pluginversion__min_qg_version__lte' : qg_version})
-        version_filters.update({'min_qg_version__lte' : qg_version})
+        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version)})
+        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version)})
         filters.update({'pluginversion__max_qg_version__gte' : qg_version})
         version_filters.update({'max_qg_version__gte' : qg_version})
 
@@ -1046,7 +1066,7 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
             WHERE (
                 pv.approved = True
                 AND pv."max_qg_version" >= '%(qg_version)s'
-                AND pv."min_qg_version" <= '%(qg_version)s'
+                AND pv."min_qg_version" <= '%(qg_version_with_patch)s'
                 AND pv.experimental = %(experimental)s
             )
             ORDER BY pv.plugin_id, pv.version DESC
@@ -1057,6 +1077,7 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
             'pv_table': PluginVersion._meta.db_table,
             'p_table': Plugin._meta.db_table,
             'qg_version': qg_version,
+            'qg_version_with_patch': _add_patch_version(qg_version),
             'experimental': 'False',
             'trusted_users_ids': str(trusted_users_ids),
         })
@@ -1069,6 +1090,7 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
                 'pv_table': PluginVersion._meta.db_table,
                 'p_table': Plugin._meta.db_table,
                 'qg_version': qg_version,
+                'qg_version_with_patch': _add_patch_version(qg_version),
                 'experimental': 'True',
                 'trusted_users_ids': str(trusted_users_ids),
             })]

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -903,7 +903,7 @@ def version_detail(request, package_name, version):
 from django.views.decorators.cache import cache_page
 
 
-def _add_patch_version(version: str) -> str:
+def _add_patch_version(version: str, additional_patch: str ) -> str:
     """To add patch number in version.
 
     e.g qgis version = 3.16 we add patch number (99) in versioning -> 3.16.99
@@ -918,8 +918,7 @@ def _add_patch_version(version: str) -> str:
     v = version.split(separator)
     if len(v) > 1:
         two_first_segment = separator.join(v[:2])
-        max_patch_version = 99
-        version = f'{two_first_segment}.{max_patch_version}'
+        version = f'{two_first_segment}.{additional_patch}'
     return version
 
 
@@ -944,10 +943,10 @@ def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
     object_list = []
 
     if qg_version:
-        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version)})
-        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version)})
-        filters.update({'pluginversion__max_qg_version__gte' : qg_version})
-        version_filters.update({'max_qg_version__gte' : qg_version})
+        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        filters.update({'pluginversion__max_qg_version__gte' : _add_patch_version(qg_version, '0')})
+        version_filters.update({'max_qg_version__gte' : _add_patch_version(qg_version, '0')})
 
 
     # Get all versions for the given plugin)
@@ -1021,10 +1020,10 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
     object_list = []
 
     if qg_version:
-        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version)})
-        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version)})
-        filters.update({'pluginversion__max_qg_version__gte' : qg_version})
-        version_filters.update({'max_qg_version__gte' : qg_version})
+        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        filters.update({'pluginversion__max_qg_version__gte' : _add_patch_version(qg_version, '0')})
+        version_filters.update({'max_qg_version__gte' : _add_patch_version(qg_version, '0')})
 
     # Get all versions for the given plugin
     if package_name:
@@ -1065,8 +1064,8 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
             FROM %(pv_table)s pv
             WHERE (
                 pv.approved = True
-                AND pv."max_qg_version" >= '%(qg_version)s'
-                AND pv."min_qg_version" <= '%(qg_version_with_patch)s'
+                AND pv."max_qg_version" >= '%(qg_version_with_patch_0)s'
+                AND pv."min_qg_version" <= '%(qg_version_with_patch_99)s'
                 AND pv.experimental = %(experimental)s
             )
             ORDER BY pv.plugin_id, pv.version DESC
@@ -1076,8 +1075,8 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
         object_list_new = PluginVersion.objects.raw(sql % {
             'pv_table': PluginVersion._meta.db_table,
             'p_table': Plugin._meta.db_table,
-            'qg_version': qg_version,
-            'qg_version_with_patch': _add_patch_version(qg_version),
+            'qg_version_with_patch_0': _add_patch_version(qg_version, '0'),
+            'qg_version_with_patch_99': _add_patch_version(qg_version, '99'),
             'experimental': 'False',
             'trusted_users_ids': str(trusted_users_ids),
         })
@@ -1089,8 +1088,8 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
             object_list_new += [o for o in PluginVersion.objects.raw(sql % {
                 'pv_table': PluginVersion._meta.db_table,
                 'p_table': Plugin._meta.db_table,
-                'qg_version': qg_version,
-                'qg_version_with_patch': _add_patch_version(qg_version),
+                'qg_version_with_patch_0': _add_patch_version(qg_version, '0'),
+                'qg_version_with_patch_99': _add_patch_version(qg_version, '99'),
                 'experimental': 'True',
                 'trusted_users_ids': str(trusted_users_ids),
             })]


### PR DESCRIPTION
This is to fix qgis/QGIS-Django#223 

Proposed solution:
Add the 3rd segment with max number as a patch number version (eg. 3.6.99) in `qgis` version against the query, so that the PluginVersion with minimum qgis version 3.16.x will be available in QGIS 3.16

![image](https://user-images.githubusercontent.com/40058076/144362930-e04df543-1476-444b-9776-04af61aa88d6.png)
