### PR TITLE
Update docs how to seed db from fixtures 

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,11 @@ If you have a backup, you can restore it:
 ```bash
 make dbrestore
 ```
-otherwise, you will have to create the superuser, adding menu etc.
+
+otherwise, you can seed initial data from fixtures:
+```
+make dbseed
+```
 
 - Set up python interpreter in PyCharm or just runserver from devweb container:
 ```bash

--- a/dockerize/Makefile
+++ b/dockerize/Makefile
@@ -119,3 +119,10 @@ dbrestore:
 	@docker exec -t  $(PROJECT_ID)-db pg_restore /backups/latest.dmp | docker exec -i $(PROJECT_ID)-db su - postgres -c "psql gis"
 	@docker-compose -p $(PROJECT_ID) start web
 	@echo "starting web container"
+
+dbseed:
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Seed db with JSON data from /fixtures/*.json"
+	@echo "------------------------------------------------------------------"
+	@docker-compose -p $(PROJECT_ID) exec devweb bash -c 'python manage.py loaddata fixtures/*.json'


### PR DESCRIPTION
If you try to run the app for first time locally on docker using docker-compose (or the according make commands) it throws errors on the server side because it needs some Menu object. Loading the existing fixture files solves the problem. 