### PR TITLE
Replace 'Owners' by 'Collaborators'

### DIFF
--- a/qgis-app/plugins/docs/introduction.rst
+++ b/qgis-app/plugins/docs/introduction.rst
@@ -9,7 +9,7 @@ The Plugin model
 
 The plugin model represents a QGIS plugin and holds general informations such as title and description and icon.
 
-The plugin can have zero or more *owners*, *owners* have the same permissions of the original plugin creator.
+The plugin can have zero or more *owners* (also named 'collaborators'), *owners* have the same permissions of the original plugin creator.
 
 Permissions
 -----------

--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -131,7 +131,7 @@
                         <a href="{% url "user_details" object.created_by %}">{{ object.created_by }}</a>
                     </dd>
                     {% if object.owners.count %}
-                        <dt>{% trans "Owners"%}</dt>
+                        <dt>{% trans "Collaborators"%}</dt>
                         <dd>
                             {% for owner in object.owners.all %}
                             <a href="{% url "user_details" owner.username %}">{{ owner.username }}</a>{% if not forloop.last %},{% endif %}


### PR DESCRIPTION
The word 'Owner' seems to be even more powerful than the other roles. Namely, 'Authors' and 'Maintainers'.
'Collaborator' fits better with the original intention, i.e., enable teammates to collaborate uploading newer plugin versions.

Note this just replaces the alias and doesn't touch the model.