### PR TITLE
Remove plugin tags to reduce distraction

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_base.html
+++ b/qgis-app/plugins/templates/plugins/plugin_base.html
@@ -36,11 +36,6 @@
         <li><a href="{% url "most_rated_plugins" %}">{% trans "Most rated" %}</a></li>
         <li><a href="{% url "server_plugins" %}">{% trans "QGIS Server plugins" %}</a></li>
 </ul>
-
-<div class="module_menu">
-    <h3>{% trans "Plugin tags" %}</h3>
-    {% include_plugins_tagcloud 'plugins.plugin' %}
-</div>
 {% endblock %}
 
 {% block "credits" %}

--- a/qgis-app/templates/flatpages/homepage.html
+++ b/qgis-app/templates/flatpages/homepage.html
@@ -37,10 +37,6 @@
             </ul>
         </div>
         {% endif %}
-        <div class="module_menu">
-            <h3>{% trans "Plugin tags" %}</h3>
-            {% include_plugins_tagcloud 'plugins.plugin' %}
-        </div>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
The `Plugin tags` section is very long and puts the Sponsors footer very far down so that maybe rarely anone ever sees it. This PR suggests removing it from the main pages.

![image](https://user-images.githubusercontent.com/21113500/185782166-e58d2a94-5f8e-422e-a3af-fd9f91c77318.png)

Above: with `Plugin tags` ; Below: without `Plugin tags`

![image](https://user-images.githubusercontent.com/21113500/185782220-07549be4-9ac6-4bfc-a56c-a9b62f144afd.png)
