### PR TITLE
Fix min_qg_version query in plugins.xml (#224)

### DIFF
--- a/qgis-app/plugins/tests/test_view.py
+++ b/qgis-app/plugins/tests/test_view.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+
+from plugins.views import _add_patch_version
+
+
+class TestTruncateVersion(TestCase):
+    """Test _add_patch_version function"""
+
+    def test__add_patch_version_with_3_segment_version_number(self):
+        version = '1.2.3'
+        self.assertEqual(_add_patch_version(version, '99'), '1.2.3')
+
+    def test__add_patch_version_with_2_segment_version_number(self):
+        version = '1.2'
+        self.assertEqual(_add_patch_version(version, '00'), '1.2.00')
+
+    def test__add_patch_version_with_1_segment_version_number(self):
+        version = '1'
+        self.assertEqual(_add_patch_version(version, '99'), '1')
+
+    def test__add_patch_version_with_None(self):
+        version = None
+        self.assertEqual(_add_patch_version(version, '99'), None)
+
+    def test__add_patch_version_with_empty_string(self):
+        version = ''
+        self.assertEqual(_add_patch_version(version, '99'), '')

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -1059,6 +1059,25 @@ def version_detail(request, package_name, version):
 from django.views.decorators.cache import cache_page
 
 
+def _add_patch_version(version: str, additional_patch: str ) -> str:
+    """To add patch number in version.
+
+    e.g qgis version = 3.16 we add patch number (99) in versioning -> 3.16.99
+    We use this versioning to query against PluginVersion min_qg_version,
+    so that the query result will include all PluginVersion with
+    minimum QGIS version 3.16 regardless of the patch number.
+    """
+
+    if not version:
+        return version
+    separator = '.'
+    v = version.split(separator)
+    if len(v) == 2:
+        two_first_segment = separator.join(v[:2])
+        version = f'{two_first_segment}.{additional_patch}'
+    return version
+
+
 @cache_page(60 * 15)
 def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
     """
@@ -1092,10 +1111,10 @@ def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
     object_list = []
 
     if qg_version:
-        filters.update({"pluginversion__min_qg_version__lte": qg_version})
-        version_filters.update({"min_qg_version__lte": qg_version})
-        filters.update({"pluginversion__max_qg_version__gte": qg_version})
-        version_filters.update({"max_qg_version__gte": qg_version})
+        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        filters.update({'pluginversion__max_qg_version__gte' : _add_patch_version(qg_version, '0')})
+        version_filters.update({'max_qg_version__gte' : _add_patch_version(qg_version, '0')})
 
     # Get all versions for the given plugin)
     if package_name:
@@ -1208,10 +1227,10 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
     object_list = []
 
     if qg_version:
-        filters.update({"pluginversion__min_qg_version__lte": qg_version})
-        version_filters.update({"min_qg_version__lte": qg_version})
-        filters.update({"pluginversion__max_qg_version__gte": qg_version})
-        version_filters.update({"max_qg_version__gte": qg_version})
+        filters.update({'pluginversion__min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        version_filters.update({'min_qg_version__lte' : _add_patch_version(qg_version, '99')})
+        filters.update({'pluginversion__max_qg_version__gte' : _add_patch_version(qg_version, '0')})
+        version_filters.update({'max_qg_version__gte' : _add_patch_version(qg_version, '0')})
 
     # Get all versions for the given plugin
     if package_name:
@@ -1256,8 +1275,8 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
             FROM %(pv_table)s pv
             WHERE (
                 pv.approved = True
-                AND pv."max_qg_version" >= '%(qg_version)s'
-                AND pv."min_qg_version" <= '%(qg_version)s'
+                AND pv."max_qg_version" >= '%(qg_version_with_patch_0)s'
+                AND pv."min_qg_version" <= '%(qg_version_with_patch_99)s'
                 AND pv.experimental = %(experimental)s
             )
             ORDER BY pv.plugin_id, pv.version DESC
@@ -1274,22 +1293,27 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
             }
         )
 
-        if stable_only != "1":
+        object_list_new = PluginVersion.objects.raw(sql % {
+            'pv_table': PluginVersion._meta.db_table,
+            'p_table': Plugin._meta.db_table,
+            'qg_version_with_patch_0': _add_patch_version(qg_version, '0'),
+            'qg_version_with_patch_99': _add_patch_version(qg_version, '99'),
+            'experimental': 'False',
+            'trusted_users_ids': str(trusted_users_ids),
+        })
+
+
+        if stable_only != '1':
             # Do the query
             object_list_new = [o for o in object_list_new]
-            object_list_new += [
-                o
-                for o in PluginVersion.objects.raw(
-                    sql
-                    % {
-                        "pv_table": PluginVersion._meta.db_table,
-                        "p_table": Plugin._meta.db_table,
-                        "qg_version": qg_version,
-                        "experimental": "True",
-                        "trusted_users_ids": str(trusted_users_ids),
-                    }
-                )
-            ]
+            object_list_new += [o for o in PluginVersion.objects.raw(sql % {
+                'pv_table': PluginVersion._meta.db_table,
+                'p_table': Plugin._meta.db_table,
+                'qg_version_with_patch_0': _add_patch_version(qg_version, '0'),
+                'qg_version_with_patch_99': _add_patch_version(qg_version, '99'),
+                'experimental': 'True',
+                'trusted_users_ids': str(trusted_users_ids),
+            })]
 
     return render(
         request,


### PR DESCRIPTION
* fix min_qg_version query

* added 0 patch value for qgis version against max_qg_version

* only add patch if it has major.minor version

From https://github.com/qgis/QGIS-Django/pull/224