### PR TITLE
Show plugin tags as modal

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_base.html
+++ b/qgis-app/plugins/templates/plugins/plugin_base.html
@@ -36,6 +36,10 @@
         <li><a href="{% url "most_rated_plugins" %}">{% trans "Most rated" %}</a></li>
         <li><a href="{% url "server_plugins" %}">{% trans "QGIS Server plugins" %}</a></li>
 </ul>
+
+<hr>
+{% include_plugins_tagcloud_modal 'plugins.plugin' %}
+
 {% endblock %}
 
 {% block "credits" %}

--- a/qgis-app/plugins/templates/plugins/plugins_tagcloud_modal_include.html
+++ b/qgis-app/plugins/templates/plugins/plugins_tagcloud_modal_include.html
@@ -1,0 +1,17 @@
+{% load i18n plugins_tagcloud %}
+
+{% trans "Plugin Tags" as tags_title %}
+
+<a href="#tagcloudModal" role="button" class="btn btn-block btn-info btn-large my-1" data-toggle="modal"><i class="icon-tags icon-white icon-2x" style="vertical-align: middle;"></i> {{ tags_title }}</a>
+
+<div id="tagcloudModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="tag_cloud_modal">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+      <h3>{{ tags_title }}</h3>
+    </div>
+    <div class="modal-body">
+    {% include_plugins_tagcloud 'plugins.plugin' %}
+    </div>
+  </div>
+</div>

--- a/qgis-app/plugins/templates/plugins/plugins_tagcloud_modal_include.html
+++ b/qgis-app/plugins/templates/plugins/plugins_tagcloud_modal_include.html
@@ -2,7 +2,11 @@
 
 {% trans "Plugin Tags" as tags_title %}
 
-<a href="#tagcloudModal" role="button" class="btn btn-block btn-info btn-large my-1" data-toggle="modal"><i class="icon-tags icon-white icon-2x" style="vertical-align: middle;"></i> {{ tags_title }}</a>
+<a id="tagcloudModalButton" href="#tagcloudModal" role="button" class="btn btn-block btn-link btn-large" data-toggle="modal">
+  <i class="icon-tags icon-white icon-2x"></i>
+  {{ tags_title }}
+  <i class="icon-resize-full icon-white"></i>
+</a>
 
 <div id="tagcloudModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="tag_cloud_modal">

--- a/qgis-app/plugins/templatetags/plugins_tagcloud.py
+++ b/qgis-app/plugins/templatetags/plugins_tagcloud.py
@@ -90,6 +90,8 @@ def get_plugins_tagcloud(context, asvar):
 def include_plugins_tagcloud(forvar=None):
     pass
 
+def include_plugins_tagcloud_modal(forvar=None):
+    pass
 
 def include_plugins_taglist(forvar=None):
     pass
@@ -98,4 +100,7 @@ def include_plugins_taglist(forvar=None):
 register.inclusion_tag("plugins/plugins_taglist_include.html")(include_plugins_taglist)
 register.inclusion_tag("plugins/plugins_tagcloud_include.html")(
     include_plugins_tagcloud
+)
+register.inclusion_tag("plugins/plugins_tagcloud_modal_include.html")(
+    include_plugins_tagcloud_modal
 )

--- a/qgis-app/static/style/style.css
+++ b/qgis-app/static/style/style.css
@@ -24,6 +24,20 @@ div.tag_cloud a {
    margin: 4px;
 }
 
+.tag_cloud_modal {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 767px) {
+  .tag_cloud_modal {
+    flex-direction: column-reverse;
+    /* place in reach of thumb */
+  }
+}
+
+
 .white, .white a {
   color: #fff;
 }
@@ -63,4 +77,14 @@ img.plugin-icon {
   #collapse-related-plugins {
     height: auto;
   }
+}
+
+.modal {
+  /* make modal fullscreen */
+  bottom: 20px;
+}
+
+.modal-header {
+  border-bottom: none;
+  text-align: center;
 }

--- a/qgis-app/static/style/style.css
+++ b/qgis-app/static/style/style.css
@@ -37,6 +37,13 @@ div.tag_cloud a {
   }
 }
 
+#tagcloudModalButton {
+  text-decoration: none;
+}
+
+#tagcloudModalButton i {
+  vertical-align: middle;
+}
 
 .white, .white a {
   color: #fff;

--- a/qgis-app/templates/flatpages/homepage.html
+++ b/qgis-app/templates/flatpages/homepage.html
@@ -36,6 +36,10 @@
             </ul>
         </div>
         {% endif %}
+
+        <hr>
+        {% include_plugins_tagcloud_modal 'plugins.plugin' %}
+
 {% endblock %}
 
 {% block rightbar %}


### PR DESCRIPTION
After playing around I prefer this modal / popup way to a dedicated page, which would be a bit unelegant and also involves more changes. 
@kannes , @m-kuhn  what you think?

So now tags could be browsed like this on desktop:

![Screenshot from 2022-12-14 10-07-02](https://user-images.githubusercontent.com/21113500/207635256-892ad64e-0855-4f0e-b9bc-8c2dccef0578.png)
![Screenshot from 2022-12-14 10-08-04](https://user-images.githubusercontent.com/21113500/207635310-2e105973-77d2-4158-80d5-0e8bc70d1071.png)
![Screenshot from 2022-12-14 10-07-15](https://user-images.githubusercontent.com/21113500/207635341-3e1eda17-73d7-4a16-bf41-b9b34f5d46a8.png)

And like this on mobile:

![Screenshot from 2022-12-14 10-05-14](https://user-images.githubusercontent.com/21113500/207635518-73b12634-e859-4f73-bcc3-cb19aa05feb8.png)
![Screenshot from 2022-12-14 10-08-30](https://user-images.githubusercontent.com/21113500/207635627-3a4f384d-14c6-4fbb-9298-984a0655c40f.png)
![Screenshot from 2022-12-14 10-06-35](https://user-images.githubusercontent.com/21113500/207635670-a07cf480-40ba-402c-a04d-67a528d527f3.png)
On mobile the content is at the bottom for better thumb access.


