### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/dockerize/docker/Dockerfile
+++ b/dockerize/docker/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Dimas Ciputra<dimas@kartoza.com>
 #RUN  ln -s /bin/true /sbin/initctl
 RUN apt-get clean all
 RUN apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev
-ADD REQUIREMENTS.txt /REQUIREMENTS.txt
+COPY REQUIREMENTS.txt /REQUIREMENTS.txt
 RUN pip install -r /REQUIREMENTS.txt
 RUN pip install uwsgi
 
@@ -24,7 +24,7 @@ ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
 RUN rm -rf /uwsgi.conf
-ADD uwsgi.conf /uwsgi.conf
+COPY uwsgi.conf /uwsgi.conf
 
 # Open port 8080 as we will be running our uwsgi socket on that
 EXPOSE 8080


### PR DESCRIPTION
Hi!
The Dockerfile placed at "dockerize/docker/Dockerfile" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance