### PR TITLE
Fix debian (9) stretch release issue in docker image

### DIFF
--- a/dockerize/docker/Dockerfile
+++ b/dockerize/docker/Dockerfile
@@ -5,6 +5,10 @@ MAINTAINER Dimas Ciputra<dimas@kartoza.com>
 
 #RUN  ln -s /bin/true /sbin/initctl
 RUN apt-get clean all
+
+# Debian stretch/updates release issue. please see https://serverfault.com/a/1130167
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev
 ADD REQUIREMENTS.txt /REQUIREMENTS.txt
 RUN pip install -r /REQUIREMENTS.txt


### PR DESCRIPTION
### Background:
I encountered this issue when running `make build` on my local:
```
 => ERROR [ 3/16] RUN apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev li  1.7s
------                                                                                                   
 > [ 3/16] RUN apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev:     
#0 0.472 Ign:1 http://security.debian.org/debian-security stretch/updates InRelease                      
#0 0.519 Ign:2 http://deb.debian.org/debian stretch InRelease
#0 0.519 Err:3 http://security.debian.org/debian-security stretch/updates Release
#0 0.519   404  Not Found
#0 0.550 Ign:4 http://deb.debian.org/debian stretch-updates InRelease
#0 0.583 Err:5 http://deb.debian.org/debian stretch Release
#0 0.583   404  Not Found
#0 0.616 Err:6 http://deb.debian.org/debian stretch-updates Release
#0 0.616   404  Not Found
#0 1.103 Get:7 https://deb.nodesource.com/node_10.x stretch InRelease [4585 B]
#0 1.258 Get:8 https://deb.nodesource.com/node_10.x stretch/main amd64 Packages [767 B]
#0 1.281 Reading package lists...
#0 1.670 E: The repository 'http://security.debian.org/debian-security stretch/updates Release' does no longer have a Release file.
#0 1.670 E: The repository 'http://deb.debian.org/debian stretch Release' does no longer have a Release file.
#0 1.670 E: The repository 'http://deb.debian.org/debian stretch-updates Release' does no longer have a Release file.
------
Dockerfile:8
--------------------
   6 |     #RUN  ln -s /bin/true /sbin/initctl
   7 |     RUN apt-get clean all
   8 | >>> RUN apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev
   9 |     ADD REQUIREMENTS.txt /REQUIREMENTS.txt
  10 |     RUN pip install -r /REQUIREMENTS.txt
--------------------

```

### Proposed solution:
There was a discussion on https://serverfault.com/questions/1074688/security-debian-org-does-not-have-a-release-file-on-with-debian-docker-images.

This PR is to use stretch main contrib non-free package repository. It did fix my issue, however, **I'm not sure if the `non-free` package can be used in this project**.


