### PR TITLE
Making license file not required for now

### DIFF
--- a/qgis-app/plugins/forms.py
+++ b/qgis-app/plugins/forms.py
@@ -180,7 +180,7 @@ class PackageUploadForm(forms.Form):
         """
         package = self.cleaned_data.get("package")
         try:
-            self.cleaned_data.update(validator(package, plugin_is_new=True))
+            self.cleaned_data.update(validator(package))
         except ValidationError as e:
             msg = _(
                 "There were errors reading plugin package (please check also your plugin's metadata)."

--- a/qgis-app/plugins/tests/test_validator.py
+++ b/qgis-app/plugins/tests/test_validator.py
@@ -200,31 +200,32 @@ class TestLicenseValidator(TestCase):
 
     def setUp(self) -> None:
         plugin_without_license = os.path.join(TESTFILE_DIR, "plugin_without_license.zip_")
-        self.invalid_plugin = open(plugin_without_license, "rb")
+        self.plugin_package = open(plugin_without_license, "rb")
 
     def tearDown(self):
-        self.invalid_plugin.close()
+        self.plugin_package.close()
 
-    def test_new_plugin_without_license(self):
-        self.assertRaises(
-            ValidationError,
-            validator,
-            InMemoryUploadedFile(
-                self.invalid_plugin,
-                field_name="tempfile",
-                name="testfile.zip",
-                content_type="application/zip",
-                size=39889,
-                charset="utf8",
-            ),
-            plugin_is_new=True
-        )
+    # License file is just recommended for now
+    # def test_new_plugin_without_license(self):
+    #     self.assertRaises(
+    #         ValidationError,
+    #         validator,
+    #         InMemoryUploadedFile(
+    #             self.plugin_package,
+    #             field_name="tempfile",
+    #             name="testfile.zip",
+    #             content_type="application/zip",
+    #             size=39889,
+    #             charset="utf8",
+    #         ),
+    #         plugin_is_new=True
+    #     )
 
-    def test_update_plugin_without_license(self):
+    def test_plugin_without_license(self):
         self.assertTrue(
             validator(
                 InMemoryUploadedFile(
-                    self.invalid_plugin,
+                    self.plugin_package,
                     field_name="tempfile",
                     name="testfile.zip",
                     content_type="application/zip",

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -146,7 +146,7 @@ def _check_url_link(url: str, forbidden_url: str, metadata_attr: str) -> None:
         raise error_check_if_exist
 
 
-def validator(package, plugin_is_new=False):
+def validator(package):
     """
     Analyzes a zipped file, returns metadata if success, False otherwise.
     If the new icon metadata is found, an inmemory file object is also returned
@@ -331,10 +331,7 @@ def validator(package, plugin_is_new=False):
     # according to https://github.com/qgis/QGIS-Django/issues/38#issuecomment-1824010198
     licensename = package_name + "/LICENSE"
     if licensename not in namelist:
-        if plugin_is_new:
-            raise ValidationError(_("Cannot find LICENSE in the plugin package. This file is required for a new plugin, please consider adding it to the plugin package."))
-        else:
-            metadata.append(("license_recommended", "Yes"))
+        metadata.append(("license_recommended", "Yes"))
 
     zip.close()
     del zip

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -468,6 +468,16 @@ def plugin_upload(request):
                         fail_silently=True,
                     )
 
+                if form.cleaned_data.get("license_recommended"):
+                    messages.warning(
+                        request,
+                        _(
+                            "Cannot find LICENSE in the plugin package. This file is not required but recommended, please consider adding it to the plugin package."
+                        ),
+                        fail_silently=True,
+                    )
+                    del form.cleaned_data["license_recommended"]
+
             except (IntegrityError, ValidationError, DjangoUnicodeDecodeError) as e:
                 connection.close()
                 messages.error(request, e, fail_silently=True)
@@ -961,7 +971,7 @@ def version_create(request, package_name):
                     messages.warning(
                         request,
                         _(
-                            "Cannot find LICENSE in the plugin package. This file is not required for updating the plugin but is recommended, please consider adding it to the plugin package."
+                            "Cannot find LICENSE in the plugin package. This file is not required but recommended, please consider adding it to the plugin package."
                         ),
                         fail_silently=True,
                     )
@@ -1017,7 +1027,7 @@ def version_update(request, package_name, version):
                     messages.warning(
                         request,
                         _(
-                            "Cannot find LICENSE in the plugin package. This file is not required for updating the plugin but is recommended, please consider adding it to the plugin package."
+                            "Cannot find LICENSE in the plugin package. This file is not required but recommended, please consider adding it to the plugin package."
                         ),
                         fail_silently=True,
                     )

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -472,7 +472,7 @@ def plugin_upload(request):
                     messages.warning(
                         request,
                         _(
-                            "Cannot find LICENSE in the plugin package. This file is not required but recommended, please consider adding it to the plugin package."
+                            "Please note that as of 1 June 2024, providing a license file will be mandatory for any new updates to existing plugins and for any new plugins published."
                         ),
                         fail_silently=True,
                     )
@@ -971,7 +971,7 @@ def version_create(request, package_name):
                     messages.warning(
                         request,
                         _(
-                            "Cannot find LICENSE in the plugin package. This file is not required but recommended, please consider adding it to the plugin package."
+                            "Please note that as of 1 June 2024, providing a license file will be mandatory for any new updates to existing plugins and for any new plugins published."
                         ),
                         fail_silently=True,
                     )
@@ -1027,7 +1027,7 @@ def version_update(request, package_name, version):
                     messages.warning(
                         request,
                         _(
-                            "Cannot find LICENSE in the plugin package. This file is not required but recommended, please consider adding it to the plugin package."
+                            "Please note that as of 1 June 2024, providing a license file will be mandatory for any new updates to existing plugins and for any new plugins published."
                         ),
                         fail_silently=True,
                     )


### PR DESCRIPTION
According to the discussion and suggestions at https://lists.osgeo.org/pipermail/qgis-developer/2023-November/066275.html, this PR is a fix for the breaking change on the plugin upload/update workflow. This is about the following issue:

- #38 

For now, a license file should be recommended. When missing, it should generate a non-blocking warning either for new or existing plugins. 

Please find below a screenshot of the warning when uploading or updating a plugin package that doesn't contain a license file:
![Screenshot 2023-11-27 at 3 51 39 PM](https://github.com/qgis/QGIS-Django/assets/43842786/863c1d63-3368-4344-b493-14d7c5cb2a97)


