### PR TITLE
Add links to plugin details tabs

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -38,6 +38,44 @@
             });
         });
     });
+
+    // Handle URL anchor for tabs
+    $(window).load(function() {
+
+        // Store the current scroll position
+        var scrollPosition = 0;
+
+        // Handle tab clicks
+        $('.nav-tabs a').on('click', function (e) {
+            e.preventDefault();
+
+            // Store the current scroll position
+            scrollPosition = $(window).scrollTop();
+
+            // Update the URL without triggering a reload
+            window.location.hash = this.hash;
+
+            // Show the tab
+            $(this).tab('show');
+        });
+
+        // Restore the scroll position on tab change
+        $('.nav-tabs a').on('shown.bs.tab', function (e) {
+            $(window).scrollTop(scrollPosition);
+        });
+
+        // Activate the tab based on the URL fragment
+        var hash = window.location.hash;
+        if (hash) {
+            $('.nav-tabs a[href="' + hash + '"]').tab('show');
+        }
+
+        // Scroll to the top when the page loads
+        setTimeout(() => {
+            $(window).scrollTop(0);
+        })
+
+    });
 </script>
 {% endblock %}
 {% block extracss %}


### PR DESCRIPTION
- This PR is for the following issue: #313 

In the current PR, each tab in a plugin detail page has a link. For example:
- About: https://plugins.qgis.org/plugins/qfieldsync/#plugin-about
- Details: https://plugins.qgis.org/plugins/qfieldsync/#plugin-details
- Versions:  https://plugins.qgis.org/plugins/qfieldsync/#plugin-versions

Please find below an animated GIF showing this feature:
![Anchor_link](https://github.com/qgis/QGIS-Django/assets/43842786/8f3987f7-ea62-4f86-b073-f7d266c98fd9)
