### PR TITLE
Show plugins with patch versions in plugin list

### DIFF
--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -1315,11 +1315,13 @@ def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
         * package_name: Plugin.package_name
 
     """
+    request_version = request.GET.get("qgis", "1.8.0")
+    version_level = len(str(request_version).split('.')) - 1
     qg_version = (
         qg_version
         if qg_version is not None
         else vjust(
-            request.GET.get("qgis", "1.8.0"), fillchar="0", level=2, force_zero=True
+            request_version, fillchar="0", level=version_level, force_zero=True
         )
     )
     stable_only = (
@@ -1431,11 +1433,13 @@ def xml_plugins_new(request, qg_version=None, stable_only=None, package_name=Non
         * package_name: Plugin.package_name
 
     """
+    request_version = request.GET.get("qgis", "1.8.0")
+    version_level = len(str(request_version).split('.')) - 1
     qg_version = (
         qg_version
         if qg_version is not None
         else vjust(
-            request.GET.get("qgis", "1.8.0"), fillchar="0", level=2, force_zero=True
+            request_version, fillchar="0", level=version_level, force_zero=True
         )
     )
     stable_only = (


### PR DESCRIPTION
This PR is for the issue #223 

## Changes summary:

According to the discussion at #224 and https://github.com/qgis/QGIS-Django/pull/224#issuecomment-1308214178, only request with major.minor QGIS version returns results in production because the plugins xml is pre-generated. 

The suggestion in issue #223 is to include the plugins with patch versions in the plugin list :
> As a short-term fix, I think we can assume the users are using the latest patch release and we should list the plugin in 3.16 list, even if it has minimumVersion=3.16.1.

Please find below a screenshot of a test plugin with minimumVersion=3.34.1:
![image](https://github.com/qgis/QGIS-Django/assets/43842786/fcb017dc-346b-4c66-97d4-77f0dffd0f41)

EDIT: This PR should also fix the issue #74 
