### PR TITLE
Keep approve status when updating style

### DIFF
--- a/qgis-app/styles/views.py
+++ b/qgis-app/styles/views.py
@@ -100,7 +100,6 @@ class StyleUpdateView(ResourceMixin, ResourceBaseUpdateView):
                 symbol_type=xml_parse["type"]
             ).first()
         obj.require_action = False
-        obj.approved = False
         obj.save()
         resource_notify(obj, created=False, resource_type=self.resource_name)
         msg = _("The Style has been successfully updated.")


### PR DESCRIPTION
- The current PR is for the issue #321 

## Change summary:
- When updating a style, the status of approbation will be kept. 
- If a style has been already approved, the updated version will be automatically approved:

![Style_update](https://github.com/qgis/QGIS-Django/assets/43842786/2bd738ad-0532-4e5d-82cc-f17970bb42a4)

- If a style is still in review, the updated version will also still be in review:

![Style_update_in_review](https://github.com/qgis/QGIS-Django/assets/43842786/f5477227-f01f-477c-abf4-5bbf4eae2e00)

