### PR TITLE
Disable matomo cookies tracking

### DIFF
--- a/qgis-app/templates/matomo/tracking_code.html
+++ b/qgis-app/templates/matomo/tracking_code.html
@@ -1,0 +1,23 @@
+<!-- Matomo -->
+<script type="text/javascript">
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function () {
+        var u = "{{ url }}";
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '{{ id }}']);
+        var d = document,
+            g = d.createElement('script'),
+            s = d.getElementsByTagName('script')[0];
+        g.type = 'text/javascript';
+        g.async = true;
+        g.src = u + 'matomo.js';
+        s.parentNode.insertBefore(g, s);
+    })();
+</script>
+<noscript>
+    <img src="{{ url }}matomo.php?idsite={{ id }}&rec=1" style="border:0" alt="" />
+</noscript>


### PR DESCRIPTION
This PR addresses the following comment: https://github.com/qgis/QGIS-Django/pull/320#issuecomment-1862298058

## Changes summary

- Disable matomo cookies tracking to keep the cookie disclaimer

Please find below the screenshot of cookies before and after disabling matomo cookies

![Matomo_cookies](https://github.com/qgis/QGIS-Django/assets/43842786/68603d8e-dec2-404b-a732-4814ecde904c) ![Matomo_cookies_disabled](https://github.com/qgis/QGIS-Django/assets/43842786/b08c09ec-52cf-4268-8720-bea4540ba0db)


