### PR TITLE
Split media and static folders

### DIFF
--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -1,4 +1,7 @@
 version: "3.8"
+volumes:
+  django-statics-data: {}
+  django-media-data: {}
 services:
   db:
     container_name: qgis-plugins-db
@@ -28,8 +31,8 @@ services:
       - RABBITMQ_HOST=rabbitmq
     volumes:
       - ../qgis-app:/home/web/django_project
-      - ./static:/home/web/static:rw
-      - ./static:/home/web/media:rw
+      - django-statics-data:/home/web/static:rw
+      - django-media-data:/home/web/media:rw
     links:
       - db:db
       - rabbitmq:rabbitmq
@@ -54,8 +57,8 @@ services:
       - RABBITMQ_HOST=rabbitmq
     volumes:
       - ../qgis-app:/home/web/django_project
-      - ./static:/home/web/static:rw
-      - ./static:/home/web/media:rw
+      - django-statics-data:/home/web/static:rw
+      - django-media-data:/home/web/media:rw
     links:
       - db:db
       - rabbitmq:rabbitmq
@@ -95,8 +98,8 @@ services:
       - RABBITMQ_HOST=rabbitmq
     volumes:
       - ../qgis-app:/home/web/django_project
-      - ./static:/home/web/static:rw
-      - ./static:/home/web/media:rw
+      - django-statics-data:/home/web/static:rw
+      - django-media-data:/home/web/media:rw
     links:
       - db:db
       - rabbitmq:rabbitmq
@@ -108,9 +111,8 @@ services:
     hostname: nginx
     volumes:
       - ./sites-enabled:/etc/nginx/conf.d:ro
-      # I dont use volumes_from as I want to use the ro modifier
-      - ./static:/home/web/static:ro
-      - ./static:/home/web/media:ro
+      - django-statics-data:/home/web/static:ro
+      - django-media-data:/home/web/media:ro
       - ./logs:/var/log/nginx
     links:
       - web:uwsgi

--- a/qgis-app/plugins/management/commands/cleanmediafolder.py
+++ b/qgis-app/plugins/management/commands/cleanmediafolder.py
@@ -8,11 +8,11 @@ class Command(BaseCommand):
     help = 'Run collectstatic and delete folders from media that exist in static'
 
     def handle(self, *args, **options):
-        confirm = input(f"Do you want to run 'collectstatic' first? (yes/no): ")
+        confirm = input("Do you want to run 'collectstatic' first? (yes/no): ")
         if confirm.lower() == 'yes':
             # Run collectstatic command
             call_command('collectstatic', interactive=False)
-        
+
         # Get the paths of static and media folders
         static_root = settings.STATIC_ROOT
         media_root = settings.MEDIA_ROOT
@@ -35,4 +35,4 @@ class Command(BaseCommand):
                 else:
                     self.stdout.write(self.style.WARNING(f'Skipped deletion of {static_dir}.'))
 
-        self.stdout.write(self.style.SUCCESS(f'The media folder has been cleaned.'))
+        self.stdout.write(self.style.SUCCESS('The media folder has been cleaned.'))

--- a/qgis-app/plugins/management/commands/cleanmediafolder.py
+++ b/qgis-app/plugins/management/commands/cleanmediafolder.py
@@ -1,0 +1,38 @@
+import os
+from shutil import rmtree
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    help = 'Run collectstatic and delete folders from media that exist in static'
+
+    def handle(self, *args, **options):
+        confirm = input(f"Do you want to run 'collectstatic' first? (yes/no): ")
+        if confirm.lower() == 'yes':
+            # Run collectstatic command
+            call_command('collectstatic', interactive=False)
+        
+        # Get the paths of static and media folders
+        static_root = settings.STATIC_ROOT
+        media_root = settings.MEDIA_ROOT
+
+        # Iterate over each directory in the static folder
+        for static_dir in os.listdir(static_root):
+            static_path = os.path.join(static_root, static_dir)
+
+            # Check if the path is a directory and exists in the media folder
+            if os.path.isdir(static_path) and os.path.exists(os.path.join(media_root, static_dir)):
+                confirm = input(f"Are you sure you want to delete '{static_dir}' from the media folder? (yes/no): ")
+
+                if confirm.lower() == 'yes':
+                    try:
+                        # Delete the corresponding folder in the media folder
+                        rmtree(os.path.join(media_root, static_dir))
+                        self.stdout.write(self.style.SUCCESS(f'Deleted {static_dir} from media folder.'))
+                    except Exception as e:
+                        self.stderr.write(self.style.ERROR(f'Error deleting {static_dir}: {str(e)}'))
+                else:
+                    self.stdout.write(self.style.WARNING(f'Skipped deletion of {static_dir}.'))
+
+        self.stdout.write(self.style.SUCCESS(f'The media folder has been cleaned.'))


### PR DESCRIPTION
- This PR will prevent deleting files from media folders (cache, geopackages, models, packages, styles, wavefronts) when running `python manage.py collectstatic --clear`. 

This is also for:
-  #298 
- #114 

## Changes summary 

- Use differents volumes for media and static in docker-compose for dev environment
- Add a command to collectstatic and delete folders from media that exist in static

## Requirements on the server-side

- Update the `docker-compose.yml` for rancher to keep the current volume for media and use a different volume for static. For example:
```
volumes:
    - django-statics-data:/home/web/static:rw
    - the_current_volume:/home/web/media:rw
```
It's better to update this file in the code to match the configuration on rancher (confirmation needed)

- Restart the rancher server and run `python manage.py collecstatic` to generate the static folders inside `django-statics-data`
- (Optional) After making sure that everything is okay, we can delete all static folders inside `the_current_volume` by running `cleanmediafolder`