### PR TITLE
Fix svg icons display issue in plugin list and plugin detail

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -1,5 +1,6 @@
 {% extends 'plugins/plugin_base.html' %}{% load i18n static thumbnail %}
 {% load local_timezone %}
+{% load plugin_utils %}
 {% block extrajs %}
 {{ block.super }}
 <script type="text/javascript" src="{% static "js/jquery.cookie.js" %}"></script>
@@ -96,9 +97,15 @@
         {% endif %}
             <h2>{{ object.name }}
             {% if object.icon and object.icon.file %}
-                {% thumbnail object.icon "128x128" upscale=False format="PNG" as im %}
-                    <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
-                {% endthumbnail %}
+                {% with image_extension=object.icon.name|file_extension %}
+                    {% if image_extension == 'svg' %}
+                        <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ object.icon.url }}" width="24" height="24" />
+                    {% else %}
+                        {% thumbnail object.icon "128x128" upscale=False format="PNG" as im %}
+                            <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
+                        {% endthumbnail %}
+                    {% endif %}
+                {% endwith %}
             {% endif %}
             </h2>
         </div>

--- a/qgis-app/plugins/templates/plugins/plugin_list.html
+++ b/qgis-app/plugins/templates/plugins/plugin_list.html
@@ -1,5 +1,6 @@
 {% extends 'plugins/plugin_base.html' %}{% load i18n bootstrap_pagination humanize static sort_anchor range_filter thumbnail %}
 {% load local_timezone %}
+{% load plugin_utils %}
 {% block extrajs %}
   <script type="text/javascript" src="{% static "js/jquery.cookie.js" %}"></script>
   <script language="javascript">
@@ -80,9 +81,15 @@
             <tr class="pmain {% if object.deprecated %} error deprecated{% endif %}" id="pmain{{object.pk}}">
                 <td><a title="{% if object.deprecated %} [DEPRECATED] {% endif %}{% trans "Click here for plugin details" %}" href="{% url "plugin_detail" object.package_name %}">
                 {% if object.icon and object.icon.file %}
-                {% thumbnail object.icon "24x24" format="PNG" as im %}
-                    <img class="plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
-                {% endthumbnail %}
+                    {% with image_extension=object.icon.name|file_extension %}
+                        {% if image_extension == 'svg' %}
+                            <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ object.icon.url }}" width="24" height="24" />
+                        {% else %}
+                            {% thumbnail object.icon "24x24" format="PNG" as im %}
+                                <img class="plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
+                            {% endthumbnail %}
+                        {% endif %}
+                    {% endwith %}
                 {% else %}
                     <img height="32" width="32" class="plugin-icon" src="{% static "images/qgis-icon-32x32.png" %}" alt="{% trans "Plugin icon" %}" />
                 {% endif %}

--- a/qgis-app/plugins/templatetags/plugin_utils.py
+++ b/qgis-app/plugins/templatetags/plugin_utils.py
@@ -24,3 +24,7 @@ def plugin_title(context):
     if "page_title" in context:
         title = context["page_title"]
     return title
+
+@register.filter
+def file_extension(value):
+    return value.split('.')[-1].lower()


### PR DESCRIPTION
- This PR is for the following issue: #65 

## Changes summary:

- Show SVG icons directly in the plugins list and the plugin detail page since `solr-thumbnail` doesn't support them

QuickOSM is an example of a plugin that uses an SVG icon:

![image](https://github.com/qgis/QGIS-Django/assets/43842786/54e86c4c-02c5-4b01-8d64-9e9325760199)

![image](https://github.com/qgis/QGIS-Django/assets/43842786/7416504e-6891-4fff-937d-2f22e7478ef4)
