### PR TITLE
Show review form for style managers

### DIFF
--- a/qgis-app/base/views/processing_view.py
+++ b/qgis-app/base/views/processing_view.py
@@ -307,6 +307,7 @@ class ResourceBaseDetailView(ResourceBaseContextMixin, DetailView):
             context["reviewer"] = reviewer
         if user.is_staff or is_resources_manager(user):
             context["form"] = ResourceBaseReviewForm(resource_name=self.resource_name)
+            context["is_style_manager"] = is_resources_manager(user)
         if self.is_3d_model:
             context["url_viewer"] = "%s_viewer" % self.resource_name_url_base
         return context

--- a/qgis-app/styles/tests/test_views.py
+++ b/qgis-app/styles/tests/test_views.py
@@ -72,6 +72,13 @@ class TestUploadStyle(TestCase):
                 },
             )
         self.assertEqual(self.response.status_code, 200)
+
+        # Should send email to style managers
+        self.assertEqual(
+            mail.outbox[0].recipients(),
+            ['staff@email.com']
+        )
+
         # style should be in Waiting Review
         url = reverse("style_unapproved")
         self.response = self.client.get(url)

--- a/qgis-app/templates/base/review.html
+++ b/qgis-app/templates/base/review.html
@@ -65,7 +65,7 @@
                     {% endwith %}
                 {% endif %}
 
-                {% if user.is_staff %}
+                {% if user.is_staff or is_style_manager %}
                 <form method="post" action="{% url url_review pk=object_detail.id %}">{% csrf_token %}
                     <dt>Approval</dt>
                     <dd>


### PR DESCRIPTION
Currently, only staff users can review (approve or reject) a style.

## Changes summary

This PR is a fix to show the style review form for staff users and users in the Group `Style Managers`.

![image](https://github.com/qgis/QGIS-Django/assets/43842786/470cc892-6d53-4e15-b49a-43c0ec5727be)

## Requirements

In the administration panel, the permissions for that Group should be updated (Chosen permissions are empty):

![image](https://github.com/qgis/QGIS-Django/assets/43842786/7928b2a9-da26-47e3-b62d-0bb0cbf3a242)
