### PR TITLE
Set media and static path as the same as in production

### DIFF
--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -12,7 +12,7 @@ ALLOWED_HOSTS = ["*"]
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/var/www/example.com/media/"
-MEDIA_ROOT = os.environ.get("MEDIA_ROOT", "/home/web/media")
+MEDIA_ROOT = os.environ.get("MEDIA_ROOT", "/home/web/media/")
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
@@ -25,11 +25,11 @@ MEDIA_URL = "/media/"
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
-STATIC_ROOT = os.environ.get("STATIC_ROOT", "/home/web/static")
+STATIC_ROOT = os.environ.get("STATIC_ROOT", "/home/web/static/static/")
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
-STATIC_URL = "/static/"
+STATIC_URL = "/static/static/"
 
 INSTALLED_APPS = [
     "django.contrib.auth",

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -19,7 +19,7 @@ MEDIA_ROOT = os.environ.get("MEDIA_ROOT", "/home/web/media/")
 # Examples: "http://example.com/media/", "http://media.example.com/"
 # MEDIA_URL = '/media/'
 # setting full MEDIA_URL to be able to use it for the feeds
-MEDIA_URL = "/media/"
+MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -29,7 +29,7 @@ STATIC_ROOT = os.environ.get("STATIC_ROOT", "/home/web/static/static/")
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
-STATIC_URL = "/static/static/"
+STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 
 INSTALLED_APPS = [
     "django.contrib.auth",


### PR DESCRIPTION
This PR proposes to set the path for the media and static folder as the same as in production since we split these two.