### PR TITLE
Add UTC timezone to xml

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugins.xml
+++ b/qgis-app/plugins/templates/plugins/plugins.xml
@@ -1,4 +1,4 @@
-{% load static %}<?xml version = '1.0' encoding = 'UTF-8'?>
+{% load static %}{% load local_timezone %}<?xml version = '1.0' encoding = 'UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="{% static "style/plugins.xsl" %}" ?>
 <plugins>
     {% for version in object_list %}<pyqgis_plugin name="{{version.plugin.name}}" version="{{ version.version }}" plugin_id="{{version.plugin.id }}">
@@ -14,8 +14,8 @@
         <author_name><![CDATA[{% firstof version.plugin.author version.plugin.created_by %}]]></author_name>
         <download_url>{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.get_host }}{{ version.get_download_url }}</download_url>
         <uploaded_by><![CDATA[{{ version.created_by }}]]></uploaded_by>
-        <create_date>{{ version.plugin.created_on.isoformat }}</create_date>
-        <update_date>{{ version.created_on.isoformat }}</update_date>
+        <create_date>{{ version.plugin.created_on|local_timezone }}</create_date>
+        <update_date>{{ version.created_on|local_timezone }}</update_date>
         <experimental>{% if version.experimental %}True{% else%}False{% endif %}</experimental>
         <deprecated>{{ version.plugin.deprecated }}</deprecated>
         <tracker><![CDATA[{{ version.plugin.tracker }}]]></tracker>

--- a/qgis-app/plugins/templates/plugins/plugins.xml
+++ b/qgis-app/plugins/templates/plugins/plugins.xml
@@ -14,8 +14,8 @@
         <author_name><![CDATA[{% firstof version.plugin.author version.plugin.created_by %}]]></author_name>
         <download_url>{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.get_host }}{{ version.get_download_url }}</download_url>
         <uploaded_by><![CDATA[{{ version.created_by }}]]></uploaded_by>
-        <create_date>{{ version.plugin.created_on|local_timezone }}</create_date>
-        <update_date>{{ version.created_on|local_timezone }}</update_date>
+        <create_date>{{ version.plugin.created_on|local_timezone:"WITH-UTC" }}</create_date>
+        <update_date>{{ version.created_on|local_timezone:"WITH-UTC" }}</update_date>
         <experimental>{% if version.experimental %}True{% else%}False{% endif %}</experimental>
         <deprecated>{{ version.plugin.deprecated }}</deprecated>
         <tracker><![CDATA[{{ version.plugin.tracker }}]]></tracker>

--- a/qgis-app/plugins/templatetags/local_timezone.py
+++ b/qgis-app/plugins/templatetags/local_timezone.py
@@ -13,6 +13,8 @@ def local_timezone(date, args="LONG"):
             result = '<span class="user-timezone-short">%s</span>' % (utcdate,)
         elif args and str(args) == "SHORT_NATURAL_DAY":
             result = '<span class="user-timezone-short-naturalday">%s</span>' % (utcdate,)
+        elif  args and str(args) == "WITH-UTC":
+            result = utcdate
         else:
             result = '<span class="user-timezone">%s</span>' % (utcdate,)
     except AttributeError:


### PR DESCRIPTION
- This is a fix for #353 

## Changes summary

- Update local_timezone filter to return directly utcdate
- Apply the filter to the created date and updated date

![image](https://github.com/qgis/QGIS-Django/assets/43842786/8ebebab1-1473-4f03-b75a-82cb86cb6f30)


