### PR TITLE
Show modified date in the model list and detail

### DIFF
--- a/qgis-app/templates/base/includes/detail_object.html
+++ b/qgis-app/templates/base/includes/detail_object.html
@@ -7,8 +7,12 @@
 <dd>{{ object_detail.description|md_to_html }}</dd>
 <dt>Uploaded Date</dt>
 <dd>{{ object_detail.upload_date|date:"d F Y" }}</dd>
+{% if object_detail.review_set.last.review_date and object_detail.approved%}
 <dt>Approved Date</dt>
 <dd>{{ object_detail.review_set.last.review_date|date:"d F Y"}}</dd>
+{% endif %}
+<dt>Modified Date</dt>
+<dd>{{ object_detail.modified_date|date:"d F Y" }}</dd>
 <dt>Creator</dt>
 <dd>{{ object_detail.get_creator_name|title }}</dd>
 {% if is_qlr %}

--- a/qgis-app/templates/base/list.html
+++ b/qgis-app/templates/base/list.html
@@ -79,6 +79,7 @@
                 </th>
                 <th> {% anchor_sort_arrow 'Creator' 'creator' order_by queries %} </th>
                 <th> {% anchor_sort_arrow 'Upload Date' 'upload_date' order_by queries %} </th>
+                <th> {% anchor_sort_arrow 'Modified Date' 'modified_date' order_by queries %} </th>
                 <th></th>
             </tr>
         </thead>
@@ -105,6 +106,7 @@
                     <td>{{ object.download_count }}</td>
                     <td>{{ object.get_creator_name|title }}</td>
                     <td>{{ object.upload_date|date:"d F Y" }}</td>
+                    <td>{{ object.modified_date|date:"d F Y" }}</td>
                     <td>
                         {% if user.is_staff or user == style.creator %}
                         <a class="btn btn-primary btn-mini" href="{% url url_update object.id %}" title="{% trans "Edit" %}"><i class="icon-pencil icon-white"></i></a>&nbsp

--- a/qgis-app/templates/base/list_galery.html
+++ b/qgis-app/templates/base/list_galery.html
@@ -77,7 +77,7 @@
           <select class="pull-right">
             <option value="creator">Creator</option>
             <option value="download_count">Number of downloads</option>
-            <option value="upload_date" selected>Upload date</option>
+            <option value="modified_date" selected>Modified date</option>
             <option value="name">{{ resource_name }} name</option>
             {% if object_list.first.style_type %}<option value="type">Style type</option>{% endif %}
           </select>
@@ -105,7 +105,7 @@
                    {{ object.name}}
                  </h4>
                  <h5>
-                   {{ object.get_creator_name|title }} | {{ object.upload_date|date:"d F Y" }} | {{ object.download_count }} downloads
+                   {{ object.get_creator_name|title }} | {{ object.modified_date|date:"d F Y" }} | {{ object.download_count }} downloads
                  </h5>
                  <p>
 

--- a/qgis-app/templates/base/list_galery.html
+++ b/qgis-app/templates/base/list_galery.html
@@ -28,12 +28,12 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        height: 420px;
+        height: 380px;
         background-color: white;
     }
     img.image-demo {
         height: auto;
-        max-height: 100%;
+        max-height: 380px;
         width: auto;
         max-width: 100%;
     }
@@ -77,6 +77,7 @@
           <select class="pull-right">
             <option value="creator">Creator</option>
             <option value="download_count">Number of downloads</option>
+            <option value="upload_date" selected>Upload date</option>
             <option value="modified_date" selected>Modified date</option>
             <option value="name">{{ resource_name }} name</option>
             {% if object_list.first.style_type %}<option value="type">Style type</option>{% endif %}
@@ -105,7 +106,8 @@
                    {{ object.name}}
                  </h4>
                  <h5>
-                   {{ object.get_creator_name|title }} | {{ object.modified_date|date:"d F Y" }} | {{ object.download_count }} downloads
+                   {{ object.get_creator_name|title }} | {{ object.upload_date|date:"d F Y" }} | {{ object.download_count }} downloads
+                   <p><em>Modified Date: {{ object.modified_date|date:"d F Y" }}</em></p>
                  </h5>
                  <p>
 


### PR DESCRIPTION
- This is a proposed fix for #375 

## Changes summary

- Show the field `Modified date` in the model list and the model details
- Show the field `Modified date` in the model gallery

![image](https://github.com/qgis/QGIS-Django/assets/43842786/fe844152-8949-4d89-a902-c16813fe1456)

![image](https://github.com/qgis/QGIS-Django/assets/43842786/d5a4319b-641d-439c-b99b-9c42f0c32290)

![image](https://github.com/qgis/QGIS-Django/assets/43842786/07e799fc-1bfa-462c-8e7d-7bd94d72f429)
