### PR TITLE
Show the path for forbidden dir in child folder

### DIFF
--- a/qgis-app/plugins/tests/test_validator.py
+++ b/qgis-app/plugins/tests/test_validator.py
@@ -159,7 +159,7 @@ class TestValidatorForbiddenFileFolder(TestCase):
             Exception,
             (
                 "For security reasons, zip file cannot contain <strong> '__MACOSX' </strong> directory. "
-                "However, it has been found in your root folder."
+                "However, there is one present at the root of the archive."
              ),
         ):
             validator(self.package)
@@ -171,7 +171,7 @@ class TestValidatorForbiddenFileFolder(TestCase):
             Exception,
             (
                 "For security reasons, zip file cannot contain <strong> '__pycache__' </strong> directory. "
-                "However, it has been found in your root folder."
+                "However, there is one present at the root of the archive."
             ),
         ):
             validator(self.package)
@@ -195,7 +195,7 @@ class TestValidatorForbiddenFileFolder(TestCase):
             Exception,
             (
                 "For security reasons, zip file cannot contain <strong> '.git' </strong> directory. "
-                "However, it has been found in your root folder."
+                "However, there is one present at the root of the archive."
             ),
         ):
             validator(self.package)
@@ -210,7 +210,7 @@ class TestValidatorForbiddenFileFolder(TestCase):
         self.assertNotEqual(
             exception.message,
             "For security reasons, zip file cannot contain <strong> '.git' </strong> directory. ",
-            "However, it has been found in your root folder."
+            "However, there is one present at the root of the archive."
         )
 
 

--- a/qgis-app/plugins/tests/test_validator.py
+++ b/qgis-app/plugins/tests/test_validator.py
@@ -157,7 +157,10 @@ class TestValidatorForbiddenFileFolder(TestCase):
         mock_namelist.return_value = ["__MACOSX/"]
         with self.assertRaisesMessage(
             Exception,
-            ("For security reasons, zip file cannot contain " "'__MACOSX' directory"),
+            (
+                "For security reasons, zip file cannot contain <strong> '__MACOSX' </strong> directory. "
+                "However, it has been found in your root folder."
+             ),
         ):
             validator(self.package)
 
@@ -167,8 +170,20 @@ class TestValidatorForbiddenFileFolder(TestCase):
         with self.assertRaisesMessage(
             Exception,
             (
-                "For security reasons, zip file cannot contain "
-                "'__pycache__' directory"
+                "For security reasons, zip file cannot contain <strong> '__pycache__' </strong> directory. "
+                "However, it has been found in your root folder."
+            ),
+        ):
+            validator(self.package)
+
+    @mock.patch("zipfile.ZipFile.namelist")
+    def test_zipfile_with_pycache_in_children(self, mock_namelist):
+        mock_namelist.return_value = ["path/to/__pycache__/"]
+        with self.assertRaisesMessage(
+            Exception,
+            (
+                "For security reasons, zip file cannot contain <strong> '__pycache__' </strong> directory. "
+                "However, it has been found at <strong> 'path/to/__pycache__/' </strong>."
             ),
         ):
             validator(self.package)
@@ -178,7 +193,10 @@ class TestValidatorForbiddenFileFolder(TestCase):
         mock_namelist.return_value = [".git"]
         with self.assertRaisesMessage(
             Exception,
-            ("For security reasons, zip file cannot contain " "'.git' directory"),
+            (
+                "For security reasons, zip file cannot contain <strong> '.git' </strong> directory. "
+                "However, it has been found in your root folder."
+            ),
         ):
             validator(self.package)
 
@@ -191,7 +209,8 @@ class TestValidatorForbiddenFileFolder(TestCase):
         exception = cm.exception
         self.assertNotEqual(
             exception.message,
-            "For security reasons, zip file cannot contain '.git' directory",
+            "For security reasons, zip file cannot contain <strong> '.git' </strong> directory. ",
+            "However, it has been found in your root folder."
         )
 
 

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -195,7 +195,7 @@ def validator(package):
                     raise ValidationError(
                         _(
                             "For security reasons, zip file "
-                            "cannot contain <strong> '%s' </strong> directory. However, it has been found in your root folder." % (forbidden_dir,)
+                            "cannot contain <strong> '%s' </strong> directory. However, there is one present at the root of the archive." % (forbidden_dir,)
                         )
                     )
                 raise ValidationError(

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -189,11 +189,19 @@ def validator(package):
                 _("For security reasons, zip file cannot contain .pyc file")
             )
         for forbidden_dir in ["__MACOSX", ".git", "__pycache__"]:
-            if forbidden_dir in zname.split("/"):
+            dir_name_list = zname.split("/")
+            if forbidden_dir in dir_name_list:
+                if forbidden_dir == dir_name_list[0]:
+                    raise ValidationError(
+                        _(
+                            "For security reasons, zip file "
+                            "cannot contain <strong> '%s' </strong> directory. However, it has been found in your root folder." % (forbidden_dir,)
+                        )
+                    )
                 raise ValidationError(
                     _(
                         "For security reasons, zip file "
-                        "cannot contain '%s' directory" % (forbidden_dir,)
+                        "cannot contain <strong> '%s' </strong> directory. However, it has been found at <strong> '%s' </strong>." % (forbidden_dir, zname)
                     )
                 )
     bad_file = zip.testzip()


### PR DESCRIPTION
This is a proposed fix for #312 

If the forbidden dir is in the root folder:

![image](https://github.com/qgis/QGIS-Django/assets/43842786/b6ea7af1-7813-400d-ac23-8ccee00570fc)

If the forbidden dir is inside a child folder:

![image](https://github.com/qgis/QGIS-Django/assets/43842786/ee1a4b6d-059e-45b9-9872-c7077b1c0136)


