### PR TITLE
Add Layer Definition File and 3D Model to the resource API

### DIFF
--- a/qgis-app/api/serializers.py
+++ b/qgis-app/api/serializers.py
@@ -40,6 +40,8 @@ class ResourceBaseSerializer(serializers.ModelSerializer):
         return attrs
 
     def get_resource_type(self, obj):
+        if self.Meta.model.__name__ == "Wavefront":
+            return "3DModel"
         return self.Meta.model.__name__
 
 

--- a/qgis-app/api/serializers.py
+++ b/qgis-app/api/serializers.py
@@ -4,6 +4,8 @@ from models.models import Model
 from rest_framework import serializers
 from sorl_thumbnail_serializer.fields import HyperlinkedSorlImageField
 from styles.models import Style
+from layerdefinitions.models import LayerDefinition
+from wavefronts.models import Wavefront
 
 
 class ResourceBaseSerializer(serializers.ModelSerializer):
@@ -62,3 +64,18 @@ class StyleSerializer(ResourceBaseSerializer):
 
     class Meta(ResourceBaseSerializer.Meta):
         model = Style
+
+class LayerDefinitionSerializer(ResourceBaseSerializer):
+    class Meta(ResourceBaseSerializer.Meta):
+        model = LayerDefinition
+
+    def get_resource_subtype(self, obj):
+        return None
+
+
+class WavefrontSerializer(ResourceBaseSerializer):
+    class Meta(ResourceBaseSerializer.Meta):
+        model = Wavefront
+
+    def get_resource_subtype(self, obj):
+        return None

--- a/qgis-app/api/tests/test_views.py
+++ b/qgis-app/api/tests/test_views.py
@@ -87,11 +87,11 @@ class TestResourceAPIList(TestCase):
             approved=True,
         )
 
-        # create Wavefront
+        # create 3D model
         Wavefront.objects.create(
             creator=self.creator0,
             name="flooded buildings extractor",
-            description="A Wavefront for testing purpose",
+            description="A 3D model for testing purpose",
             thumbnail_image=self.thumbnail,
             file=self.file,
             approved=True,
@@ -116,7 +116,7 @@ class TestResourceAPIList(TestCase):
                 s_index = i
             elif d["resource_type"] == "LayerDefinition":
                 l_index = i
-            elif d["resource_type"] == "Wavefront":
+            elif d["resource_type"] == "3DModel":
                 w_index = i
         self.assertIsNotNone(g_index)
         self.assertIsNotNone(m_index)
@@ -136,7 +136,7 @@ class TestResourceAPIList(TestCase):
         self.assertEqual(result[l_index]["resource_subtype"], None)
         self.assertEqual(result[l_index]["creator"], "creator 0")
 
-        self.assertEqual(result[w_index]["resource_type"], "Wavefront")
+        self.assertEqual(result[w_index]["resource_type"], "3DModel")
         self.assertEqual(result[w_index]["resource_subtype"], None)
         self.assertEqual(result[w_index]["creator"], "creator 0")
 
@@ -167,7 +167,7 @@ class TestResourceAPIList(TestCase):
                 s_index = i
             elif d["resource_type"] == "LayerDefinition":
                 l_index = i
-            elif d["resource_type"] == "Wavefront":
+            elif d["resource_type"] == "3DModel":
                 w_index = i
         self.assertIsNotNone(g_index)
         self.assertIsNone(m_index)
@@ -196,7 +196,7 @@ class TestResourceAPIList(TestCase):
                 s_index = i
             elif d["resource_type"] == "LayerDefinition":
                 l_index = i
-            elif d["resource_type"] == "Wavefront":
+            elif d["resource_type"] == "3DModel":
                 w_index = i
         self.assertIsNone(g_index)
         self.assertIsNone(m_index)
@@ -225,7 +225,7 @@ class TestResourceAPIList(TestCase):
                 s_index = i
             elif d["resource_type"] == "LayerDefinition":
                 l_index = i
-            elif d["resource_type"] == "Wavefront":
+            elif d["resource_type"] == "3DModel":
                 w_index = i
         self.assertIsNone(g_index)
         self.assertIsNotNone(m_index)
@@ -254,7 +254,7 @@ class TestResourceAPIList(TestCase):
                 s_index = i
             elif d["resource_type"] == "LayerDefinition":
                 l_index = i
-            elif d["resource_type"] == "Wavefront":
+            elif d["resource_type"] == "3DModel":
                 w_index = i
         self.assertIsNotNone(g_index)
         self.assertIsNotNone(m_index)

--- a/qgis-app/api/tests/test_views.py
+++ b/qgis-app/api/tests/test_views.py
@@ -12,6 +12,8 @@ from django.urls import reverse
 from geopackages.models import Geopackage
 from models.models import Model
 from styles.models import Style, StyleType
+from layerdefinitions.models import LayerDefinition
+from wavefronts.models import Wavefront
 
 
 @override_settings(MEDIA_ROOT="api/tests")
@@ -75,6 +77,26 @@ class TestResourceAPIList(TestCase):
             approved=True,
         )
 
+        # create LayerDefinition
+        LayerDefinition.objects.create(
+            creator=self.creator0,
+            name="flooded buildings extractor",
+            description="A LayerDefinition for testing purpose",
+            thumbnail_image=self.thumbnail,
+            file=self.file,
+            approved=True,
+        )
+
+        # create Wavefront
+        Wavefront.objects.create(
+            creator=self.creator0,
+            name="flooded buildings extractor",
+            description="A Wavefront for testing purpose",
+            thumbnail_image=self.thumbnail,
+            file=self.file,
+            approved=True,
+        )
+
     def tearDown(self):
         pass
 
@@ -83,7 +105,7 @@ class TestResourceAPIList(TestCase):
         url = reverse("resource-list")
         response = self.client.get(url)
         json_parse = json.loads(response.content)
-        self.assertEqual(json_parse["total"], 3)
+        self.assertEqual(json_parse["total"], 5)
         result = json_parse["results"]
         for i, d in enumerate(result):
             if d["resource_type"] == "Geopackage":
@@ -92,15 +114,32 @@ class TestResourceAPIList(TestCase):
                 m_index = i
             elif d["resource_type"] == "Style":
                 s_index = i
+            elif d["resource_type"] == "LayerDefinition":
+                l_index = i
+            elif d["resource_type"] == "Wavefront":
+                w_index = i
         self.assertIsNotNone(g_index)
         self.assertIsNotNone(m_index)
         self.assertIsNotNone(s_index)
+        self.assertIsNotNone(l_index)
+        self.assertIsNotNone(w_index)
+
         self.assertEqual(result[g_index]["resource_type"], "Geopackage")
         self.assertEqual(result[g_index]["resource_subtype"], None)
         self.assertEqual(result[g_index]["creator"], "creator")
+
         self.assertEqual(result[m_index]["resource_type"], "Model")
         self.assertEqual(result[m_index]["resource_subtype"], None)
         self.assertEqual(result[m_index]["creator"], "creator 0")
+
+        self.assertEqual(result[l_index]["resource_type"], "LayerDefinition")
+        self.assertEqual(result[l_index]["resource_subtype"], None)
+        self.assertEqual(result[l_index]["creator"], "creator 0")
+
+        self.assertEqual(result[w_index]["resource_type"], "Wavefront")
+        self.assertEqual(result[w_index]["resource_subtype"], None)
+        self.assertEqual(result[w_index]["creator"], "creator 0")
+
         self.assertEqual(result[s_index]["resource_type"], "Style")
         self.assertEqual(result[s_index]["resource_subtype"], "Marker")
         self.assertEqual(result[s_index]["creator"], "creator")
@@ -117,6 +156,8 @@ class TestResourceAPIList(TestCase):
         g_index = None
         m_index = None
         s_index = None
+        l_index = None
+        w_index = None
         for i, d in enumerate(result):
             if d["resource_type"] == "Geopackage":
                 g_index = i
@@ -124,30 +165,15 @@ class TestResourceAPIList(TestCase):
                 m_index = i
             elif d["resource_type"] == "Style":
                 s_index = i
+            elif d["resource_type"] == "LayerDefinition":
+                l_index = i
+            elif d["resource_type"] == "Wavefront":
+                w_index = i
         self.assertIsNotNone(g_index)
         self.assertIsNone(m_index)
         self.assertIsNone(s_index)
-
-    def test_get_list_resources_with_filter_resource_type(self):
-        param = "resource_type=geopackage"
-        url = "%s?%s" % (reverse("resource-list"), param)
-        response = self.client.get(url)
-        json_parse = json.loads(response.content)
-        self.assertEqual(json_parse["total"], 1)
-        result = json_parse["results"]
-        g_index = None
-        m_index = None
-        s_index = None
-        for i, d in enumerate(result):
-            if d["resource_type"] == "Geopackage":
-                g_index = i
-            elif d["resource_type"] == "Model":
-                m_index = i
-            elif d["resource_type"] == "Style":
-                s_index = i
-        self.assertIsNotNone(g_index)
-        self.assertIsNone(m_index)
-        self.assertIsNone(s_index)
+        self.assertIsNone(l_index)
+        self.assertIsNone(w_index)
 
     def test_get_list_resources_with_filter_resource_subtype(self):
         param = "resource_subtype=Marker"
@@ -159,6 +185,8 @@ class TestResourceAPIList(TestCase):
         g_index = None
         m_index = None
         s_index = None
+        l_index = None
+        w_index = None
         for i, d in enumerate(result):
             if d["resource_type"] == "Geopackage":
                 g_index = i
@@ -166,33 +194,18 @@ class TestResourceAPIList(TestCase):
                 m_index = i
             elif d["resource_type"] == "Style":
                 s_index = i
+            elif d["resource_type"] == "LayerDefinition":
+                l_index = i
+            elif d["resource_type"] == "Wavefront":
+                w_index = i
         self.assertIsNone(g_index)
         self.assertIsNone(m_index)
+        self.assertIsNone(l_index)
+        self.assertIsNone(w_index)
         self.assertIsNotNone(s_index)
 
     def test_get_list_resources_with_filter_creator(self):
         param = "creator=creator 0"
-        url = "%s?%s" % (reverse("resource-list"), param)
-        response = self.client.get(url)
-        json_parse = json.loads(response.content)
-        self.assertEqual(json_parse["total"], 1)
-        result = json_parse["results"]
-        g_index = None
-        m_index = None
-        s_index = None
-        for i, d in enumerate(result):
-            if d["resource_type"] == "Geopackage":
-                g_index = i
-            elif d["resource_type"] == "Model":
-                m_index = i
-            elif d["resource_type"] == "Style":
-                s_index = i
-        self.assertIsNone(g_index)
-        self.assertIsNotNone(m_index)
-        self.assertIsNone(s_index)
-
-    def test_get_list_resources_with_filter_keyword(self):
-        param = "keyword=testing"
         url = "%s?%s" % (reverse("resource-list"), param)
         response = self.client.get(url)
         json_parse = json.loads(response.content)
@@ -201,6 +214,8 @@ class TestResourceAPIList(TestCase):
         g_index = None
         m_index = None
         s_index = None
+        l_index = None
+        w_index = None
         for i, d in enumerate(result):
             if d["resource_type"] == "Geopackage":
                 g_index = i
@@ -208,9 +223,44 @@ class TestResourceAPIList(TestCase):
                 m_index = i
             elif d["resource_type"] == "Style":
                 s_index = i
+            elif d["resource_type"] == "LayerDefinition":
+                l_index = i
+            elif d["resource_type"] == "Wavefront":
+                w_index = i
+        self.assertIsNone(g_index)
+        self.assertIsNotNone(m_index)
+        self.assertIsNotNone(l_index)
+        self.assertIsNotNone(w_index)
+        self.assertIsNone(s_index)
+
+    def test_get_list_resources_with_filter_keyword(self):
+        param = "keyword=testing"
+        url = "%s?%s" % (reverse("resource-list"), param)
+        response = self.client.get(url)
+        json_parse = json.loads(response.content)
+        self.assertEqual(json_parse["total"], 5)
+        result = json_parse["results"]
+        g_index = None
+        m_index = None
+        s_index = None
+        l_index = None
+        w_index = None
+        for i, d in enumerate(result):
+            if d["resource_type"] == "Geopackage":
+                g_index = i
+            elif d["resource_type"] == "Model":
+                m_index = i
+            elif d["resource_type"] == "Style":
+                s_index = i
+            elif d["resource_type"] == "LayerDefinition":
+                l_index = i
+            elif d["resource_type"] == "Wavefront":
+                w_index = i
         self.assertIsNotNone(g_index)
         self.assertIsNotNone(m_index)
         self.assertIsNotNone(s_index)
+        self.assertIsNotNone(l_index)
+        self.assertIsNotNone(w_index)
 
     def test_download_resource_should_be_a_file_in_a_zip(self):
         url = reverse("resource-download", kwargs={"uuid": self.style.uuid})

--- a/qgis-app/api/views.py
+++ b/qgis-app/api/views.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from api.serializers import GeopackageSerializer, ModelSerializer, StyleSerializer
+from api.serializers import GeopackageSerializer, ModelSerializer, StyleSerializer, LayerDefinitionSerializer, WavefrontSerializer
 from base.license import zip_a_file_if_not_zipfile
 from django.contrib.postgres.search import SearchVector
 from django.http import Http404, HttpResponse
@@ -16,6 +16,8 @@ from models.models import Model
 from rest_framework import filters, permissions
 from rest_framework.views import APIView
 from styles.models import Style
+from layerdefinitions.models import LayerDefinition
+from wavefronts.models import Wavefront
 
 
 def filter_resource_type(queryset, request, *args, **kwargs):
@@ -115,6 +117,16 @@ class ResourceAPIList(FlatMultipleModelAPIView):
             "serializer_class": StyleSerializer,
             "filter_fn": filter_general,
         },
+        {
+            "queryset": LayerDefinition.approved_objects.all(),
+            "serializer_class": LayerDefinitionSerializer,
+            "filter_fn": filter_general,
+        },
+        {
+            "queryset": Wavefront.approved_objects.all(),
+            "serializer_class": WavefrontSerializer,
+            "filter_fn": filter_general,
+        },
     ]
 
 
@@ -135,6 +147,10 @@ class ResourceAPIDownload(APIView):
             object = Model.approved_objects.get(uuid=uuid)
         elif Style.approved_objects.filter(uuid=uuid).exists():
             object = Style.approved_objects.get(uuid=uuid)
+        elif LayerDefinition.approved_objects.filter(uuid=uuid).exists():
+            object = LayerDefinition.approved_objects.get(uuid=uuid)
+        elif Wavefront.approved_objects.filter(uuid=uuid).exists():
+            object = Wavefront.approved_objects.get(uuid=uuid)
         else:
             raise Http404
 

--- a/qgis-app/api/views.py
+++ b/qgis-app/api/views.py
@@ -22,6 +22,8 @@ from wavefronts.models import Wavefront
 
 def filter_resource_type(queryset, request, *args, **kwargs):
     resource_type = request.query_params["resource_type"]
+    if resource_type.lower() == "3dmodel":
+        resource_type = "wavefront"
     if queryset.model.__name__.lower() == resource_type.lower():
         return queryset
     else:


### PR DESCRIPTION
This is a proposed change for #280 

## Changes summary

- Return Layer Definition and Wavefront (3D Model) in the resource API
- Update unit test

![image](https://github.com/qgis/QGIS-Django/assets/43842786/b2c3ec61-85f7-4759-ac30-e9c2e22418e4)

