### PR TITLE
Remove code coverage from test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,19 +57,12 @@ jobs:
       - name: Wait for the containers to start
         run: sleep 15 
 
-      - name: Run Coverage test
+      - name: Run test
         run: |
           docker-compose exec -T devweb bash -c '
             set -e  # Exit immediately if any command fails
-            pip install coverage &&
             python manage.py makemigrations &&
             python manage.py migrate &&
-            coverage run manage.py test &&
-            coverage xml
+            python manage.py test
           '
 
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I think the workflow at https://github.com/qgis/QGIS-Django/actions/runs/8924797767/job/24515483333 fails because it couldn't find the Codecov token on the repo. For now, I suggest to run the workflow without it. 