### PR TITLE
Change db collation to en_GB

### DIFF
--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -16,8 +16,12 @@ services:
       - POSTGRES_USER=${DATABASE_USERNAME:-docker}
       - POSTGRES_PASS=${DATABASE_PASSWORD:-docker}
       - PASSWORD_AUTHENTICATION=${PASSWORD_AUTHENTICATION:-md5}
+      - DATADIR=/opt/postgres/data
+      - DEFAULT_ENCODING=UTF8
+      - DEFAULT_COLLATION=en_GB.utf8
+      - DEFAULT_CTYPE=en_GB.utf8
     volumes:
-      - postgres_data:/var/lib/postgresql
+      - postgres_data:/opt/postgres/data
       - ${QGISPLUGINS_BACKUP_VOLUME}:/backups
     restart: unless-stopped
 


### PR DESCRIPTION
- This is a proposed fix for #45

As mentioned in #15 :

> The database in the production server must be in C collation. 

## Change summary

- Change default DB collation to `en_GB.utf8` to get non-case-sensitive data from the DB
- This change should be applied with #374 to avoid any change to the DB when it's in production

![image](https://github.com/qgis/QGIS-Django/assets/43842786/8382cff1-1ea1-4ada-a419-843955d9313a)