### PR TITLE
Update deprecated decodestring method to decodebytes to fix RPC2 upload

### DIFF
--- a/qgis-app/plugins/middleware.py
+++ b/qgis-app/plugins/middleware.py
@@ -14,7 +14,7 @@ def HttpAuthMiddleware(get_response):
         if auth_basic and not str(auth_basic).startswith('Bearer'):
             import base64
 
-            username, dummy, password = base64.decodestring(
+            username, dummy, password = base64.decodebytes(
                 auth_basic[6:].encode("utf8")
             ).partition(b":")
             username = username.decode("utf8")


### PR DESCRIPTION
This is a fix for #397 and https://github.com/qgis/QGIS-Django/pull/374#issuecomment-2096337527

The `base64.decodestring()` function has been deprecated since Python 3.1, and removed in Python 3.9. Since we are now using Python 3.12, I've updated it to `base64.decodebytes() ` to address the issue.