### PR TITLE
Make plugin license required as of 03 June

### DIFF
--- a/qgis-app/plugins/tests/test_validator.py
+++ b/qgis-app/plugins/tests/test_validator.py
@@ -221,33 +221,18 @@ class TestLicenseValidator(TestCase):
     def tearDown(self):
         self.plugin_package.close()
 
-    # License file is just recommended for now
-    # def test_new_plugin_without_license(self):
-    #     self.assertRaises(
-    #         ValidationError,
-    #         validator,
-    #         InMemoryUploadedFile(
-    #             self.plugin_package,
-    #             field_name="tempfile",
-    #             name="testfile.zip",
-    #             content_type="application/zip",
-    #             size=39889,
-    #             charset="utf8",
-    #         ),
-    #         plugin_is_new=True
-    #     )
-
-    def test_plugin_without_license(self):
-        self.assertTrue(
-            validator(
-                InMemoryUploadedFile(
-                    self.plugin_package,
-                    field_name="tempfile",
-                    name="testfile.zip",
-                    content_type="application/zip",
-                    size=39889,
-                    charset="utf8",
-                )
+    # License file is required
+    def test_new_plugin_without_license(self):
+        self.assertRaises(
+            ValidationError,
+            validator,
+            InMemoryUploadedFile(
+                self.plugin_package,
+                field_name="tempfile",
+                name="testfile.zip",
+                content_type="application/zip",
+                size=39889,
+                charset="utf8",
             )
         )
 

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -158,7 +158,7 @@ def validator(package):
 
         * size <= PLUGIN_MAX_UPLOAD_SIZE
         * zip contains __init__.py in first level dir
-        * Check for LICENCE file
+        * Check for LICENSE file
         * mandatory metadata: ('name', 'description', 'version', 'qgisMinimumVersion', 'author', 'email')
         * package_name regexp: [A-Za-z][A-Za-z0-9-_]+
         * author regexp: [^/]+
@@ -350,12 +350,15 @@ def validator(package):
     _check_url_link(urls_to_check)
 
 
-    # Checks for LICENCE file presence
-    # This should be just a warning for now (for new version upload) 
-    # according to https://github.com/qgis/QGIS-Django/issues/38#issuecomment-1824010198
+    # Checks for LICENSE file presence
+    # Making it mandatory as of 03 June 2024 
+    # according to https://github.com/qgis/QGIS-Enhancement-Proposals/issues/279
     licensename = package_name + "/LICENSE"
     if licensename not in namelist:
-        metadata.append(("license_recommended", "Yes"))
+        raise ValidationError(_(
+            "Cannot find LICENSE in the plugin package. "
+            "This file is required, please consider adding it to the plugin package.")
+        )
 
     zip.close()
     del zip

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -486,16 +486,6 @@ def plugin_upload(request):
                         fail_silently=True,
                     )
 
-                if form.cleaned_data.get("license_recommended"):
-                    messages.warning(
-                        request,
-                        _(
-                            "Please note that as of 1 June 2024, providing a license file will be mandatory for any new updates to existing plugins and for any new plugins published."
-                        ),
-                        fail_silently=True,
-                    )
-                    del form.cleaned_data["license_recommended"]
-
                 if form.cleaned_data.get("multiple_parent_folders"):
                     parent_folders = form.cleaned_data.get("multiple_parent_folders")
                     messages.warning(
@@ -1207,16 +1197,6 @@ def _version_create(request, plugin, version, is_trusted=False):
                 if form.cleaned_data.get("icon_file"):
                     form.cleaned_data["icon"] = form.cleaned_data.get("icon_file")
 
-                if form.cleaned_data.get("license_recommended"):
-                    messages.warning(
-                        request,
-                        _(
-                            "Please note that as of 1 June 2024, providing a license file will be mandatory for any new updates to existing plugins and for any new plugins published."
-                        ),
-                        fail_silently=True,
-                    )
-                    del form.cleaned_data["license_recommended"]
-
                 if form.cleaned_data.get("multiple_parent_folders"):
                     parent_folders = form.cleaned_data.get("multiple_parent_folders")
                     messages.warning(
@@ -1291,16 +1271,6 @@ def _version_update(request, plugin, version, is_trusted=False):
                 _main_plugin_update(request, new_object.plugin, form)
                 msg = _("The Plugin Version has been successfully updated.")
                 messages.success(request, msg, fail_silently=True)
-
-                if form.cleaned_data.get("license_recommended"):
-                    messages.warning(
-                        request,
-                        _(
-                            "Please note that as of 1 June 2024, providing a license file will be mandatory for any new updates to existing plugins and for any new plugins published."
-                        ),
-                        fail_silently=True,
-                    )
-                    del form.cleaned_data["license_recommended"]
 
                 if form.cleaned_data.get("multiple_parent_folders"):
                     parent_folders = form.cleaned_data.get("multiple_parent_folders")


### PR DESCRIPTION
This is for #38 according to https://github.com/qgis/QGIS-Enhancement-Proposals/issues/279

## Changes summary

- Make the plugin license file required for any new updates to existing and new plugins published 
- Update unit test

Please find below the screenshots of the error raised when a license file is missing:

For a new plugin:

![image](https://github.com/qgis/QGIS-Django/assets/43842786/01bbe809-54af-4e83-aef3-cc2439d9b53e)

For a new version of an existing plugin:

![image](https://github.com/qgis/QGIS-Django/assets/43842786/7ae3ba49-3fb1-4f80-a682-761ab00f050a)
