### PR TITLE
Do not update the modified date of when downloading a resource

### DIFF
--- a/qgis-app/api/views.py
+++ b/qgis-app/api/views.py
@@ -139,7 +139,7 @@ class ResourceAPIDownload(APIView):
             raise Http404
 
         object.increase_download_counter()
-        object.save()
+        object.save(update_fields=['download_count'])
         # zip the resource
         zipfile = zip_a_file_if_not_zipfile(object.file.file.name)
 

--- a/qgis-app/base/views/processing_view.py
+++ b/qgis-app/base/views/processing_view.py
@@ -478,7 +478,7 @@ class ResourceBaseDownload(ResourceBaseContextMixin, View):
                 return TemplateResponse(request, self.template_name, context)
         else:
             object.increase_download_counter()
-            object.save()
+            object.save(update_fields=['download_count'])
 
         # zip the resource and license.txt
         zipfile = zipped_with_license(object.file.file.name, object.name)

--- a/qgis-app/layerdefinitions/views.py
+++ b/qgis-app/layerdefinitions/views.py
@@ -127,7 +127,7 @@ class LayerDefinitionDownloadView(ResourceMixin, ResourceBaseDownload):
                 return TemplateResponse(request, self.template_name, context)
         else:
             object.increase_download_counter()
-            object.save()
+            object.save(update_fields=['download_count'])
 
         # zip the resource and license.txt
         zipfile = zipped_with_license(

--- a/qgis-app/wavefronts/views.py
+++ b/qgis-app/wavefronts/views.py
@@ -126,7 +126,7 @@ class WavefrontDownloadView(ResourceMixin, ResourceBaseDownload):
                 return TemplateResponse(request, self.template_name, context)
         else:
             object.increase_download_counter()
-            object.save()
+            object.save(update_fields=['download_count'])
 
         # zip the 3d files folder and license.txt
         path, filename = os.path.split(object.file.file.name)


### PR DESCRIPTION
This is a patch for #381 

The `modified_date` should not be updated when the `download_count` increases because no real modification to the resource is made.