### PR TITLE
Implement rate limit in nginx configuration

### DIFF
--- a/dockerize/sites-enabled/prod-ssl.conf
+++ b/dockerize/sites-enabled/prod-ssl.conf
@@ -4,6 +4,9 @@ upstream uwsgi {
     server uwsgi:8080;
 }
 
+# Define the rate limit zone: 10 requests per second for each IP address
+limit_req_zone $binary_remote_addr zone=one:10m rate=10r/s;
+
 server {
     # OTF gzip compression
     gzip on;
@@ -66,6 +69,11 @@ server {
     }
     # Finally, send all non-media requests to the Django server.
     location / {
+
+        # Apply rate limit
+        limit_req zone=one burst=20 nodelay;
+        limit_req_status 429;
+
         uwsgi_pass  uwsgi;
         # the uwsgi_params file you installed needs to be passed with each
         # request.
@@ -184,6 +192,11 @@ server {
     }
     # Finally, send all non-media requests to the Django server.
     location / {
+
+        # Apply rate limit
+        limit_req zone=one burst=20 nodelay;
+        limit_req_status 429;
+
         uwsgi_pass  uwsgi;
         # the uwsgi_params file you installed needs to be passed with each
         # request.

--- a/dockerize/sites-enabled/prod.conf
+++ b/dockerize/sites-enabled/prod.conf
@@ -4,6 +4,9 @@ upstream uwsgi {
     server uwsgi:8080;
 }
 
+# Define the rate limit zone: 10 requests per second for each IP address
+limit_req_zone $binary_remote_addr zone=one:10m rate=10r/s;
+
 server {
     # OTF gzip compression
     gzip on;
@@ -63,6 +66,11 @@ server {
     }
     # Finally, send all non-media requests to the Django server.
     location / {
+
+        # Apply rate limit
+        limit_req zone=one burst=20 nodelay;
+        limit_req_status 429;
+
         uwsgi_pass  uwsgi;
         # the uwsgi_params file you installed needs to be passed with each
         # request.


### PR DESCRIPTION
This is for #402 according to https://github.com/qgis/QGIS-Django/issues/402#issuecomment-2136054622.

## Change summary

- Apply a rate limit of 10 requests per second for each IP address