### PR TITLE
Fix deprecated admin_static

### DIFF
--- a/qgis-app/templates/admin_copies/change_form.html
+++ b/qgis-app/templates/admin_copies/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls admin_static admin_modify %}
+{% load i18n admin_urls static admin_modify %}
 
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>


### PR DESCRIPTION
Since we've upgraded to Django 4, using `admin_static` in a template has been deprecated in favour of only `static`