### PR TITLE
Use relative path for logo in xml style

### DIFF
--- a/qgis-app/static/style/plugins.xsl
+++ b/qgis-app/static/style/plugins.xsl
@@ -76,7 +76,7 @@ td.menu_panel {
 
 </head>
 <body>
-<img src="https://plugins.qgis.org/static/static/style/new/logo.png"/>
+<img src="../static/style/new/logo.png"/>
 <h2>QGIS Python Plugins</h2>
 <p>
 NOTE: The preferred way to install QGIS plugins is via the <a href="https://docs.qgis.org/testing/en/docs/user_manual/plugins/plugins.html">Plugin Manager</a> in QGIS itself!


### PR DESCRIPTION
This is a fix for #419 

This issue has already been fixed in the past (#363) and occurred again when we migrated to the new infrastructure. I think it's better to use a relative path for the logo URL.