### PR TITLE
Handle invalid icon in plugins list and details

### DIFF
--- a/dockerize/.env.template
+++ b/dockerize/.env.template
@@ -36,6 +36,10 @@ ENABLE_LDAP=False
 # SENTRY
 SENTRY_DSN=''
 
+# Set traces_sample_rate to 1.0 to capture 100%
+# of transactions for performance monitoring.
+SENTRY_RATE=1.0
+
 # Download stats URL
 METABASE_DOWNLOAD_STATS_URL='https://plugins.qgis.org/metabase/public/dashboard/<dashboard_id>'
 

--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
       - DEFAULT_PLUGINS_SITE=${DEFAULT_PLUGINS_SITE:-https://plugins.qgis.org/}
       - SENTRY_DSN=${SENTRY_DSN}
+      - SENTRY_RATE=${SENTRY_RATE}
     volumes:
       - ../qgis-app:/home/web/django_project
       - ./docker/uwsgi.conf:/uwsgi.conf

--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -144,7 +144,7 @@
         <div class="span12">
         {% endif %}
             <h2>{{ object.name }}
-            {% if object.icon and object.icon.file %}
+            {% if object.icon and object.icon.file and object.icon|is_image_valid %}
                 {% with image_extension=object.icon.name|file_extension %}
                     {% if image_extension == 'svg' %}
                         <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ object.icon.url }}" width="24" height="24" />
@@ -154,6 +154,8 @@
                         {% endthumbnail %}
                     {% endif %}
                 {% endwith %}
+            {% else %}
+                <img height="32" width="32" class="pull-right plugin-icon" src="{% static "images/qgis-icon-32x32.png" %}" alt="{% trans "Plugin icon" %}" />
             {% endif %}
             </h2>
             <div>

--- a/qgis-app/plugins/templates/plugins/plugin_list.html
+++ b/qgis-app/plugins/templates/plugins/plugin_list.html
@@ -80,7 +80,7 @@
             {% for object in object_list %}
             <tr class="pmain {% if object.deprecated %} error deprecated{% endif %}" id="pmain{{object.pk}}">
                 <td><a title="{% if object.deprecated %} [DEPRECATED] {% endif %}{% trans "Click here for plugin details" %}" href="{% url "plugin_detail" object.package_name %}">
-                {% if object.icon and object.icon.file %}
+                {% if object.icon and object.icon.file and object.icon|is_image_valid %}
                     {% with image_extension=object.icon.name|file_extension %}
                         {% if image_extension == 'svg' %}
                             <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ object.icon.url }}" width="24" height="24" />

--- a/qgis-app/plugins/templatetags/plugin_utils.py
+++ b/qgis-app/plugins/templatetags/plugin_utils.py
@@ -1,4 +1,5 @@
 from django import template
+from PIL import Image, UnidentifiedImageError
 
 register = template.Library()
 
@@ -28,3 +29,14 @@ def plugin_title(context):
 @register.filter
 def file_extension(value):
     return value.split('.')[-1].lower()
+
+@register.filter
+def is_image_valid(image):
+    if not image:
+        return False
+    try:
+        img = Image.open(image.path)
+        img.verify()
+        return True
+    except (FileNotFoundError, UnidentifiedImageError):
+        return False

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -169,6 +169,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Sentry
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
+SENTRY_RATE = os.environ.get("SENTRY_RATE", 1.0)
 
 if SENTRY_DSN and SENTRY_DSN != "":
     import sentry_sdk
@@ -177,5 +178,5 @@ if SENTRY_DSN and SENTRY_DSN != "":
         dsn=SENTRY_DSN,
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
-        traces_sample_rate=1.0,
+        traces_sample_rate=SENTRY_RATE,
     )


### PR DESCRIPTION
This is the proposed fix for #421 

## Changes summary

- Add a filter `is_image_valid` to check for invalid images to handle errors from solr thumbnail
- Show the default QGIS icon (plugins list and detail) when a plugin's icon is invalid

![image](https://github.com/qgis/QGIS-Django/assets/43842786/1d594172-fe62-4a2b-a21a-01a0a32ad8cf)