### PR TITLE
Add command to run uwsgi in docker-compose.yml

### DIFF
--- a/dockerize/.env.template
+++ b/dockerize/.env.template
@@ -44,4 +44,4 @@ SENTRY_RATE=1.0
 METABASE_DOWNLOAD_STATS_URL='https://plugins.qgis.org/metabase/public/dashboard/<dashboard_id>'
 
 # Uwsgi Docker image
-UWSGI_DOCKER_IMAGE='kartoza/qgis-plugins-uwsgi:latest'
+UWSGI_DOCKER_IMAGE='qgis/qgis-plugins-uwsgi:latest'

--- a/dockerize/docker-compose.yml
+++ b/dockerize/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - ${QGISPLUGINS_STATIC_VOLUME}:/home/web/static:rw
       - ${QGISPLUGINS_MEDIA_VOLUME}:/home/web/media:rw
       - celerybeat-schedule:/home/web/celerybeat-schedule:rw
-    
+    command: uwsgi --ini /uwsgi.conf
     depends_on:
       - db
       - rabbitmq


### PR DESCRIPTION
## Change summary

- Add the command to init uwsgi in docker-compose.yml as it doesn't seem to run automatically when using the image from dockerhub
- Update the environment template to use the image from qgis's dockerhub by default