### PR TITLE
Prioritize the experimental flag in the metadata

### DIFF
--- a/qgis-app/plugins/forms.py
+++ b/qgis-app/plugins/forms.py
@@ -122,16 +122,6 @@ class PluginVersionForm(ModelForm):
             package = self.cleaned_data.get("package")
             try:
                 cleaned_data = validator(package)
-                if (
-                    "experimental" in dict(cleaned_data)
-                    and "experimental" in self.cleaned_data
-                    and dict(cleaned_data)["experimental"]
-                    != self.cleaned_data["experimental"]
-                ):
-                    msg = _(
-                        "The 'experimental' flag in the form does not match the 'experimental' flag in the plugins package metadata.<br />"
-                    )
-                    raise ValidationError(mark_safe("%s" % msg))
                 self.cleaned_data.update(cleaned_data)
             except ValidationError as e:
                 msg = _(


### PR DESCRIPTION
Fix for #477 

In the Upload new plugins/version form, the Experimental checkbox says: `Check this box if this version is experimental, leave unchecked if it's stable. Please note that this field might be overridden by metadata (if present).` So it would make sense to prioritise the experimental attribute in the metadata and get the value from the checkbox if it's not set.

This change removes the extra validation that compares both values and allows the expected workflow.