### PR TITLE
Add support for generic version label parameter in plugins xml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
+          - '3.12'
     steps:
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/qgis-app/plugins/utils.py
+++ b/qgis-app/plugins/utils.py
@@ -56,3 +56,36 @@ def parse_remote_addr(request: HttpRequest) -> str:
     if x_forwarded_for:
         return x_forwarded_for.split(",")[0]
     return request.META.get("REMOTE_ADDR", "")
+
+def get_version_from_label(param):
+    """
+    Fetches the QGIS version based on the given parameter.
+
+    Args:
+        param (str): The parameter to determine which version to fetch.
+                     Accepts 'ltr', 'stable', or 'latest'.
+
+    Returns:
+        str: The major and minor version of QGIS.
+
+    Raises:
+        ValueError: If the parameter value is invalid.
+        Exception: If the request to the QGIS version service fails or the version is not found.
+    """
+    if param.lower() in ['ltr', 'stable']:
+        url = 'https://version.qgis.org/version-ltr.txt'
+    elif param.lower() == 'latest':
+        url = 'https://version.qgis.org/version.txt'
+    else:
+        raise ValueError('Invalid parameter value')
+
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise Exception('Request failed')
+
+    content = response.text
+    match = re.search(r'QGIS Version \d+\|Visit .+ version (\d+\.\d+)', content)
+    if match:
+        return match.group(1)
+    else:
+        raise Exception('Version not found in response')

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -36,7 +36,7 @@ from plugins.forms import *
 from plugins.models import Plugin, PluginOutstandingToken, PluginVersion, PluginVersionDownload, vjust
 from plugins.validator import PLUGIN_REQUIRED_METADATA
 from django.contrib.gis.geoip2 import GeoIP2
-from plugins.utils import parse_remote_addr
+from plugins.utils import parse_remote_addr, get_version_from_label
 
 from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
 from rest_framework_simplejwt.tokens import RefreshToken, api_settings
@@ -1630,6 +1630,11 @@ def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
 
     """
     request_version = request.GET.get("qgis", "1.8.0")
+    if request_version in ["latest", "ltr", "stable"]:
+        numbered_version = get_version_from_label(request_version)
+        # Redirect to this view using the numbered version because
+        # the xml file is cached with that.
+        return HttpResponseRedirect(reverse("xml_plugins") + f"?qgis={numbered_version}")
     version_level = len(str(request_version).split('.')) - 1
     qg_version = (
         qg_version


### PR DESCRIPTION
Fix for #448 

- Added support for generic label parameters (`latest`, `ltr` and `stable`) in the plugin xml.
- When using one of these parameters, the view will get the numbered version from https://version.qgis.org/version.txt or version-ltr.txt (depending on the parameter).
- Redirect to the same view but using the numbered version as we already have them cached
- Note: The full version with patch is not supported so we only use the major and minor version here.

https://github.com/user-attachments/assets/98b5f0d3-312e-45b0-a516-523e7d281db5

