### PR TITLE
Add latest, ltr and stable to cache

### DIFF
--- a/dockerize/sites-enabled/prod.conf
+++ b/dockerize/sites-enabled/prod.conf
@@ -110,17 +110,3 @@ server {
   		    allow all;
   	}
 }
-
-# Redirect requests on analytics.qgis.org over to the feed
-# This is just a conveneience in case we ever decide to host
-# metabase on its own server.
-# Note that we also have a cloudflare trasnform rule in place
-# which will redirect users from analytics.qgis.org over to the public dashboard
-# https://dash.cloudflare.com/a2cec2d89cc90579a20a30365bedcaf7/qgis.org/rules/transform-rules
-server {
-    listen 80;
-    server_name plugins-analytics.qgis.org;
-    ssl_certificate /etc/letsencrypt/live/plugins-analytics.qgis.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/plugins-analytics.qgis.org/privkey.pem;
-    return 301 $scheme://plugins.qgis.org/metabase/public/dashboard/7ecd345f-7321-423d-9844-71e526a454a9;
-}

--- a/qgis-app/plugins/tests/test_task.py
+++ b/qgis-app/plugins/tests/test_task.py
@@ -46,7 +46,7 @@ class TestPluginTask(TestCase):
         # Given
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = '<some xml content>'
+        mock_response.text = '<some xml content> QGIS Version 34002|Visit https://download.qgis.org to get your copy of version 3.40.2'
         mock_get.return_value = mock_response
         preferences.SitePreference.qgis_versions = '3.24,3.25'
 
@@ -74,7 +74,7 @@ class TestPluginTask(TestCase):
         # Given
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = '<some xml content>'
+        mock_response.text = '<some xml content> QGIS Version 34002|Visit https://download.qgis.org to get your copy of version 3.40.2'
         mock_get.return_value = mock_response
         preferences.SitePreference.qgis_versions = '3.24,3.25'
 

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -1630,11 +1630,6 @@ def xml_plugins(request, qg_version=None, stable_only=None, package_name=None):
 
     """
     request_version = request.GET.get("qgis", "1.8.0")
-    if request_version in ["latest", "ltr", "stable"]:
-        numbered_version = get_version_from_label(request_version)
-        # Redirect to this view using the numbered version because
-        # the xml file is cached with that.
-        return HttpResponseRedirect(reverse("xml_plugins") + f"?qgis={numbered_version}")
     version_level = len(str(request_version).split('.')) - 1
     qg_version = (
         qg_version


### PR DESCRIPTION
- The Django redirection in #495 is overridden by the Ngnix redirection and makes the labeled version not found.
- This PR adds the latest, ltr, and stable xml files to the cache and avoid using the Django redirection.