### PR TITLE
Plugin resolved email

### DIFF
--- a/qgis-app/plugins/tests/test_plugin_version_feedback.py
+++ b/qgis-app/plugins/tests/test_plugin_version_feedback.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from freezegun import freeze_time
 
 from plugins.models import Plugin, PluginVersion, PluginVersionFeedback
-from plugins.views import version_feedback_notify
+from plugins.views import version_feedback_notify, version_feedback_resolved_notify
 from django.conf import settings
 from django.utils.dateformat import format
 import json
@@ -138,6 +138,22 @@ class TestPluginFeedbackCompletedList(SetupMixin, TestCase):
         self.client.force_login(user=self.creator)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 404)
+    
+    def test_version_feedback_resolved_notify(self):
+
+        with self.assertLogs(level='DEBUG'):
+            version_feedback_resolved_notify(self.version_1, self.staff)
+        self.assertEqual(
+            mail.outbox[0].recipients(),
+            ['admin@admin.it', 'staff@staff.it']
+        )
+
+        # Should use the new email
+        self.assertEqual(
+            mail.outbox[0].from_email,
+            settings.EMAIL_HOST_USER
+        )
+
 
     def test_staff_should_see_plugin_feedback_completed(self):
         self.client.force_login(user=self.staff)

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -232,7 +232,7 @@ def version_feedback_resolved_notify(version,  user, all_tasks):
         )
         send_mail_wrapper(
             _("Plugin %s feedback resolved notification.") % (plugin, ),
-            _("\r\nPlugin %s feedback resolved by %s.\r\nLink: http://%s%sfeedback/\r\n")
+            _("\r\nPlugin %s feedback resolved by %s.\r\nLink: http://%s%sfeedback/\r\n. The plunin is now ready for review again.")
             % (
                 plugin.name,
                 user,

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -232,7 +232,7 @@ def version_feedback_resolved_notify(version,  user, all_tasks):
         )
         send_mail_wrapper(
             _("Plugin %s feedback resolved notification.") % (plugin, ),
-            _("\r\nPlugin %s feedback resolved by %s.\r\nLink: http://%s%sfeedback/\r\n. The plunin is now ready for review again.")
+            _("\r\nPlugin %s feedback resolved by %s.\r\nLink: http://%s%sfeedback/\r\n. The plugin is now ready for review again.")
             % (
                 plugin.name,
                 user,


### PR DESCRIPTION
Proposed fix for #503 

- Send the following email to each reviewer when all the feedback is resolved: `Plugin <plugin_name> feedback resolved by <author>. Link: <plugin_version_feedback_link>. The plugin is now ready for review again.`
- Add unit test

@NyakudyaA
> Could you send an email after each item has been resolved

A plugin will only move to the `Reviewed Plugins (Resolved)` list when all items are checked. So I think, it would be more accurate to send the email when it's the case. What do you think?

Also, do you think we need to notify all the staff users when the feedback items are resolved? My suggestion here is to send the email to the reviewers only. Any staff user can still see it under the Reviewed Plugins (Resolved) list.